### PR TITLE
55.refresh header&footer

### DIFF
--- a/app/src/main/java/com/laotoua/dawnislandk/MainActivity.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/MainActivity.kt
@@ -13,8 +13,8 @@ import com.laotoua.dawnislandk.data.entity.Forum
 import com.laotoua.dawnislandk.data.state.AppState
 import com.laotoua.dawnislandk.databinding.ActivityMainBinding
 import com.laotoua.dawnislandk.ui.adapter.QuickNodeAdapter
-import com.laotoua.dawnislandk.ui.util.ToolbarUtil.updateAppBarByFragment
-import com.laotoua.dawnislandk.ui.util.ToolbarUtil.updateAppBarTitleWithinFragment
+import com.laotoua.dawnislandk.ui.util.UIUtils.updateAppBarByFragment
+import com.laotoua.dawnislandk.ui.util.UIUtils.updateAppBarTitleWithinFragment
 import com.laotoua.dawnislandk.viewmodel.CommunityViewModel
 import com.laotoua.dawnislandk.viewmodel.LoadingStatus
 import com.laotoua.dawnislandk.viewmodel.SharedViewModel

--- a/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/FeedFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/FeedFragment.kt
@@ -167,4 +167,10 @@ class FeedFragment : Fragment() {
 
         return binding.root
     }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }
+

--- a/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/FeedFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/FeedFragment.kt
@@ -137,10 +137,9 @@ class FeedFragment : Fragment() {
                         mAdapter.loadMoreModule.loadMoreFail()
                         Toast.makeText(
                             context,
-                            "${it.peekContent().message}",
+                            it.peekContent().message,
                             Toast.LENGTH_LONG
                         ).show()
-                        Timber.e(message)
                     }
                     LoadingStatus.NODATA -> {
                         binding.refreshLayout.refreshComplete()

--- a/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/SizeCustomizationFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/SizeCustomizationFragment.kt
@@ -108,7 +108,7 @@ class SizeCustomizationFragment : Fragment() {
         }
 
         generateSeekBar(ELEVATION, "阴影").let {
-            it?.findViewWithTag<SeekBar>("SeekBar")?.progress = cardFactory.cardElevaion
+            it?.findViewWithTag<SeekBar>("SeekBar")?.progress = cardFactory.cardElevation
             progressContainer.addView(it)
         }
 

--- a/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/ThreadFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/ThreadFragment.kt
@@ -84,6 +84,9 @@ class ThreadFragment : Fragment() {
         mAdapter.setSharedVM(sharedVM)
 
         mAdapter.apply {
+            // initial load
+            if (data.size == 0) binding.refreshLayout.autoRefresh(Constants.ACTION_NOTHING, false)
+
             setOnItemClickListener { adapter, _, position ->
                 hideMenu()
                 sharedVM.setThread(adapter.getItem(position) as Thread)
@@ -121,7 +124,6 @@ class ThreadFragment : Fragment() {
                 viewModel.getThreads()
             }
 
-            if (data.size == 0) binding.refreshLayout.autoRefresh(Constants.ACTION_NOTHING, false)
         }
 
         viewModel.loadingStatus.observe(viewLifecycleOwner, Observer {
@@ -139,6 +141,7 @@ class ThreadFragment : Fragment() {
             if (viewModel.currentForum == null) {
                 viewModel.setForum(it)
             } else if (viewModel.currentForum != null && viewModel.currentForum!!.id != it.id) {
+                binding.refreshLayout.autoRefresh(Constants.ACTION_NOTHING, false)
                 Timber.i("Forum has changed to ${it.name}. Cleaning old adapter data...")
                 mAdapter.setList(emptyList())
                 viewModel.setForum(it)
@@ -185,6 +188,7 @@ class ThreadFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+        Timber.d("Fragment View Destroyed")
     }
 
     private fun hideMenu() {

--- a/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/TrendFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/ui/fragment/TrendFragment.kt
@@ -62,10 +62,9 @@ class TrendFragment : Fragment() {
                         mAdapter.loadMoreModule.loadMoreFail()
                         Toast.makeText(
                             context,
-                            "${it.peekContent().message}",
+                            it.peekContent().message,
                             Toast.LENGTH_LONG
                         ).show()
-                        Timber.e(message)
                     }
                     LoadingStatus.NODATA -> {
                         binding.refreshLayout.refreshComplete()

--- a/app/src/main/java/com/laotoua/dawnislandk/ui/util/UIUtils.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/ui/util/UIUtils.kt
@@ -1,6 +1,7 @@
 package com.laotoua.dawnislandk.ui.util
 
 import android.app.Activity
+import android.widget.Toast
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
@@ -8,11 +9,15 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.appbar.AppBarLayout
 import com.laotoua.dawnislandk.R
+import com.laotoua.dawnislandk.ui.adapter.QuickAdapter
 import com.laotoua.dawnislandk.ui.fragment.*
+import com.laotoua.dawnislandk.viewmodel.EventPayload
+import com.laotoua.dawnislandk.viewmodel.LoadingStatus
 import kotlinx.android.synthetic.main.activity_main.*
+import me.dkzwm.widget.srl.SmoothRefreshLayout
 
 
-object ToolbarUtil {
+object UIUtils {
     private fun disableCollapse(activity: Activity, title: String, subtitle: String? = "") {
         val dawnAppbar = activity.dawnAppbar
         val collapsingToolbar = activity.collapsingToolbar
@@ -140,8 +145,39 @@ object ToolbarUtil {
         }
     }
 
-    // special handler for forum change
+    // update forum change when fragment is not changed
     fun Activity.updateAppBarTitleWithinFragment(title: String) {
         collapsingToolbar.title = title
+    }
+
+    fun <T> Fragment.updateHeaderAndFooter(
+        refreshLayout: SmoothRefreshLayout,
+        mAdapter: QuickAdapter,
+        event: EventPayload<T>
+    ) {
+        when (event.loadingStatus) {
+            LoadingStatus.FAILED -> {
+                refreshLayout.refreshComplete(false)
+                mAdapter.loadMoreModule.loadMoreFail()
+                Toast.makeText(
+                    context,
+                    event.message,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            LoadingStatus.NODATA -> {
+                refreshLayout.refreshComplete()
+                mAdapter.loadMoreModule.loadMoreEnd()
+            }
+            LoadingStatus.SUCCESS -> {
+                refreshLayout.refreshComplete()
+                mAdapter.loadMoreModule.loadMoreComplete()
+            }
+            LoadingStatus.LOADING -> {
+                // do nothing
+            }
+
+        }
+
     }
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/ui/viewfactory/ThreadCardFactory.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/ui/viewfactory/ThreadCardFactory.kt
@@ -26,16 +26,17 @@ class ThreadCardFactory(val context: Context) {
     private var DEFAULT_CARDVIEW_MARGINSTART = 10
     private var DEFAULT_CARDVIEW_MARGINEND = 10
     private var DEFAULT_CARDVIEW_MARGINTOP = 16
-    private var DEFAULT_CARDVIEW_MARGINBOTTOM = 6
+    private var DEFAULT_CARDVIEW_MARGINBOTTOM = 10
     private val sharedPreferences: SharedPreferences by lazy {
         PreferenceManager.getDefaultSharedPreferences(context)
     }
     var mainTextSize = 0
     var cardRadius = 0
-    var cardElevaion = 0
+    var cardElevation = 0
     var cardMarginTop = 0
     var cardMarginLeft = 0
     var cardMarginRight = 0
+    var cardMarginBottom = 0
     var headBarMarginTop = 0
     var contentMarginTop = 0
     var contentMarginLeft = 0
@@ -51,7 +52,7 @@ class ThreadCardFactory(val context: Context) {
             Constants.CARD_RADIUS,
             dip2px(context, 5f)
         )
-        cardElevaion =
+        cardElevation =
             sharedPreferences.getInt(
                 Constants.CARD_ELEVATION,
                 dip2px(context, 2f)
@@ -67,6 +68,10 @@ class ThreadCardFactory(val context: Context) {
         cardMarginRight = sharedPreferences.getInt(
             Constants.CARD_MARGIN_RIGHT,
             DEFAULT_CARDVIEW_MARGINEND
+        )
+        cardMarginBottom = sharedPreferences.getInt(
+            Constants.CARD_MARGIN_BOTTOM,
+            DEFAULT_CARDVIEW_MARGINBOTTOM
         )
         headBarMarginTop = sharedPreferences.getInt(
             Constants.HEAD_BAR_MARGIN_TOP,
@@ -110,6 +115,7 @@ class ThreadCardFactory(val context: Context) {
         marginLayoutParams.marginStart = cardMarginLeft
         marginLayoutParams.marginEnd = cardMarginRight
         marginLayoutParams.topMargin = cardMarginTop
+        marginLayoutParams.bottomMargin = cardMarginBottom
         cardView.layoutParams = marginLayoutParams
 
         /**
@@ -134,7 +140,7 @@ class ThreadCardFactory(val context: Context) {
          */
         cardView.setCardBackgroundColor(Color.parseColor("#Ffffff"))
         cardView.radius = cardRadius.toFloat()
-        cardView.elevation = cardElevaion.toFloat()
+        cardView.elevation = cardElevation.toFloat()
         val threadContainer = ConstraintLayout(context)
         threadContainer.id = R.id.threadContainer
         threadContainer.setPadding(

--- a/app/src/main/java/com/laotoua/dawnislandk/util/Constants.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/util/Constants.kt
@@ -7,6 +7,7 @@ object Constants {
     const val CARD_MARGIN_TOP = "card_margin_top"
     const val CARD_MARGIN_LEFT = "card_margin_left"
     const val CARD_MARGIN_RIGHT = "card_margin_right"
+    const val CARD_MARGIN_BOTTOM = "card_margin_bottom"
     const val HEAD_BAR_MARGIN_TOP = "head_bar_margin_top"
     const val CONTENT_MARGIN_TOP = "content_margin_top"
     const val CONTENT_MARGIN_LEFT = "content_margin_left"

--- a/app/src/main/java/com/laotoua/dawnislandk/viewmodel/TrendViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/viewmodel/TrendViewModel.kt
@@ -28,10 +28,6 @@ class TrendViewModel : ViewModel() {
     val loadingStatus: LiveData<SingleLiveEvent<EventPayload<Nothing>>>
         get() = _loadingStatus
 
-    init {
-        getLatestTrend()
-    }
-
     private fun getLatestTrend() {
         viewModelScope.launch {
             getLatestTrendPage()

--- a/app/src/main/java/com/laotoua/dawnislandk/viewmodel/TrendViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/viewmodel/TrendViewModel.kt
@@ -30,12 +30,12 @@ class TrendViewModel : ViewModel() {
 
     private fun getLatestTrend() {
         viewModelScope.launch {
+            _loadingStatus.postValue(SingleLiveEvent.create(LoadingStatus.LOADING))
             getLatestTrendPage()
         }
     }
 
     private suspend fun getLatestTrendPage() {
-
         DataResource.create(
             NMBServiceClient.getReplys(
                 AppState.cookies?.firstOrNull()?.cookieHash,

--- a/app/src/main/res/layout/reply_fragment.xml
+++ b/app/src/main/res/layout/reply_fragment.xml
@@ -14,7 +14,8 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/replysView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:scrollbars="vertical">
 
         </androidx.recyclerview.widget.RecyclerView>
     </me.dkzwm.widget.srl.SmoothRefreshLayout>

--- a/app/src/main/res/layout/thread_fragment.xml
+++ b/app/src/main/res/layout/thread_fragment.xml
@@ -6,15 +6,17 @@
     android:layout_height="match_parent"
     tools:context=".ui.fragment.ThreadFragment">
 
+    <me.dkzwm.widget.srl.SmoothRefreshLayout
+        android:id="@+id/refreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/threadsView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/threadsView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="vertical"></androidx.recyclerview.widget.RecyclerView>
+    </me.dkzwm.widget.srl.SmoothRefreshLayout>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/setting"

--- a/app/src/main/res/layout/trend_fragment.xml
+++ b/app/src/main/res/layout/trend_fragment.xml
@@ -18,7 +18,8 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/trendsView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:scrollbars="vertical">
 
         </androidx.recyclerview.widget.RecyclerView>
     </me.dkzwm.widget.srl.SmoothRefreshLayout>


### PR DESCRIPTION
close #55 

- 为卡片添加margin bottom以突出loadmore footer
- 统一header和footer的更新（都是依赖viewmodel post singleliveevent）
- 统一了每一个fragment的同一个object的设置
- 修复了订阅加载bug（删除订阅会导致页数出错）
- 所有recyclerview已配置刷新功能，以及对应的头部显示