### PR TITLE
Reply data will be saved to local DB

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,8 +28,8 @@ android {
     buildToolsVersion "29.0.3"
     android.ndkVersion "21.1.6352462"
 
-    viewBinding {
-        enabled = true
+    buildFeatures{
+         viewBinding = true
     }
 
     defaultConfig {
@@ -120,12 +120,9 @@ dependencies {
     implementation 'com.afollestad.material-dialogs:input:3.3.0'
     implementation 'com.afollestad.material-dialogs:color:3.2.1'
 
-    implementation 'me.dkzwm.widget.srl:core:1.7.1.1.androidx'
-    implementation 'me.dkzwm.widget.srl:ext-util:1.7.1.1.androidx'
-    implementation 'me.dkzwm.widget.srl:ext-material:1.7.1.1.androidx'
-    implementation 'me.dkzwm.widget.srl:ext-horizontal:1.7.1.1.androidx'
-    implementation 'me.dkzwm.widget.srl:ext-classics:1.7.1.1.androidx'
-    implementation 'me.dkzwm.widget.srl:ext-two-level:1.7.1.1.androidx'
+    implementation 'me.dkzwm.widget.srl:core:1.7.1.2.androidx'
+    implementation 'me.dkzwm.widget.srl:ext-util:1.7.1.2.androidx'
+    implementation 'me.dkzwm.widget.srl:ext-material:1.7.1.2.androidx'
 
     implementation 'com.king.zxing:zxing-lite:1.1.9-androidx'
 
@@ -157,5 +154,5 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$dagger_version"
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.3'
-
+    debugImplementation 'com.amitshekhar.android:debug-db:1.0.6'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:1.3.0-alpha04"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-alpha02"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-alpha02"
     implementation 'com.google.android.material:material:1.2.0-alpha06'
 
     def appcompat_version = "1.2.0-beta01"
@@ -106,7 +107,9 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.8.1'
     implementation 'com.squareup.retrofit2:converter-gson:2.8.1'
     implementation "com.squareup.okhttp3:okhttp:4.6.0"
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation "com.squareup.moshi:moshi-kotlin:1.9.2"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.9.2"
+
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation 'org.apache.commons:commons-text:1.8'
     implementation 'com.github.CymChad:BaseRecyclerViewAdapterHelper:3.0.2'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -29,4 +29,26 @@
 # https://issuetracker.google.com/issues/142601969
 -keepnames class androidx.navigation.fragment.NavHostFragment
 
+### moshi
+-keep class kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoaderImpl
+-keepclassmembers class kotlin.Metadata {
+    public <methods>;
+}
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+-keepclasseswithmembers class * {
+    @com.squareup.moshi.* <methods>;
+}
+
+-keep @com.squareup.moshi.JsonQualifier interface *
+
+# Enum field names are used by the integrated EnumJsonAdapter.
+# values() is synthesized by the Kotlin compiler and is used by EnumJsonAdapter indirectly
+# Annotate enums with @JsonClass(generateAdapter = false) to use them with Moshi.
+-keepclassmembers @com.squareup.moshi.JsonClass class * extends java.lang.Enum {
+    <fields>;
+    **[] values();
+}
+
 

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/ApplicationDataStore.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/ApplicationDataStore.kt
@@ -11,6 +11,7 @@ class ApplicationDataStore @Inject constructor(private val cookieDao: CookieDao)
 
     private var mCookies = mutableListOf<Cookie>()
     val cookies get() = mCookies
+    val firstCookieHash = cookies.firstOrNull()?.cookieHash
 
     private var mFeedId: String? = null
     val feedId get() = mFeedId!!

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/Community.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/Community.kt
@@ -2,24 +2,15 @@ package com.laotoua.dawnislandk.data.local
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.JsonClass
 
-@Entity(tableName = "community")
+@JsonClass(generateAdapter = true)
+@Entity
 data class Community(
-
     @PrimaryKey
-    @SerializedName("id")
     val id: String,
-
-    @SerializedName("sort")
     val sort: String,
-
-    @SerializedName("name")
     val name: String,
-
-    @SerializedName("status")
     val status: String,
-
-    @SerializedName("forums")
     val forums: List<Forum>
 )

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/Cookie.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/Cookie.kt
@@ -3,11 +3,8 @@ package com.laotoua.dawnislandk.data.local
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "cookie")
+@Entity
 data class Cookie(
-
-    @PrimaryKey
-    val cookieHash: String,
-
+    @PrimaryKey val cookieHash: String,
     var cookieName: String
 )

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/Forum.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/Forum.kt
@@ -20,6 +20,6 @@ data class Forum(
     val status: String = ""
 ) {
     fun getDisplayName(): String {
-        return if (showName != "") showName else name
+        return if (showName.isNotBlank()) showName else name
     }
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/Forum.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/Forum.kt
@@ -1,55 +1,25 @@
 package com.laotoua.dawnislandk.data.local
 
 import androidx.annotation.Keep
-import androidx.room.ColumnInfo
 import androidx.room.PrimaryKey
-import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 @Keep
 data class Forum(
     @PrimaryKey
-    @ColumnInfo(name = "id")
-    @SerializedName("id")
     val id: String,
-
-    @ColumnInfo(name = "fgroup", defaultValue = "")
-    @SerializedName("fgroup")
-    val fgroup: String? = "",
-
-    @ColumnInfo(name = "sort", defaultValue = "")
-    @SerializedName("sort")
-    val sort: String? = "",
-
-    @ColumnInfo(name = "name", defaultValue = "")
-    @SerializedName("name")
-    val name: String = "",
-
-    @ColumnInfo(name = "showName", defaultValue = "")
-    @SerializedName("showName")
-    val showName: String? = "",
-
-    @ColumnInfo(name = "msg", defaultValue = "")
-    @SerializedName("msg")
-    val msg: String? = "",
-
-    @ColumnInfo(name = "interval", defaultValue = "")
-    @SerializedName("interval")
-    val interval: String? = "",
-
-    @ColumnInfo(name = "createdAt", defaultValue = "")
-    @SerializedName("createdAt")
-    val createdAt: String? = "",
-
-    @ColumnInfo(name = "updateAt", defaultValue = "")
-    @SerializedName("updateAt")
-    val updateAt: String? = "",
-
-    @ColumnInfo(name = "status", defaultValue = "")
-    @SerializedName("status")
-    val status: String? = ""
+    val fgroup: String = "",
+    val sort: String = "",
+    val name: String,
+    val showName: String = "",
+    val msg: String,
+    val interval: String = "",
+    val createdAt: String = "",
+    val updateAt: String = "",
+    val status: String = ""
 ) {
-
     fun getDisplayName(): String {
-        return if (showName != null && showName != "") showName else name
+        return if (showName != "") showName else name
     }
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/Reply.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/Reply.kt
@@ -1,36 +1,29 @@
 package com.laotoua.dawnislandk.data.local
 
-import com.google.gson.annotations.SerializedName
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
+@Entity
 data class Reply(
-    @SerializedName("id")
-    val id: String,
-    @SerializedName("userid")
+    @PrimaryKey val id: String,
     val userid: String,
-    @SerializedName("name")
-    val name: String? = "",
-    @SerializedName("sage")
-    val sage: String? = "",
-    @SerializedName("admin")
-    val admin: String? = "1",
-    @SerializedName("status")
-    val status: String? = "n", //?
-    @SerializedName("title")
-    val title: String? = "",
-    @SerializedName("email")
+    val name: String = "",
+    val sage: String = "0",
+    val admin: String = "0",
+    val status: String = "n",
+    val title: String,
     val email: String,
-    @SerializedName("now")
     val now: String,
-    @SerializedName("content")
     val content: String,
-    @SerializedName("img")
     val img: String,
-    @SerializedName("ext")
     val ext: String,
-    @Transient
-    var page: Int? = 1
+    var page: Int = 1,
+    var parentId: String = "",
+    var lastUpdatedAt: Long = 0
 ) {
-    fun getImgUrl(): String {
-        return img + ext
-    }
+    fun getImgUrl(): String = (img + ext)
+
+    fun isNotAd(): Boolean = (id != "9999999")
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/Thread.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/Thread.kt
@@ -1,47 +1,74 @@
 package com.laotoua.dawnislandk.data.local
 
+import androidx.room.Entity
 import androidx.room.Ignore
-import com.google.gson.annotations.SerializedName
+import androidx.room.PrimaryKey
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
+@Entity
 data class Thread(
-    @SerializedName("id")
-    val id: String, //	该串的id
-    @SerializedName("fid")
-    var fid: String? = "", //	该串的fid, 非时间线的串会被设置
-
-    @Ignore
-    var forumName: String? = "",// only used for displaying name
-
-    @SerializedName("category")
-    var category: String? = "",
-
-    @SerializedName("img")
+    @PrimaryKey val id: String, //	该串的id
+    var fid: String = "", //	该串的fid, 非时间线的串会被设置
+    @Ignore var forumName: String = "",// only used for displaying name
+    var category: String = "",
     val img: String, //	该串的图片相对地址
-    @SerializedName("ext")
     val ext: String, // 	该串图片的后缀
-    @SerializedName("now")
     val now: String, // 	该串的可视化发言时间
-    @SerializedName("userid")
     val userid: String, //userid 	该串的饼干
-    @SerializedName("name")
     val name: String, //name 	你懂得
-    @SerializedName("email")
     val email: String, //email 	你懂得
-    @SerializedName("title")
     val title: String, //title 	你还是懂的(:з」∠)
-    @SerializedName("content")
     val content: String, //content 	....这个你也懂
-    @SerializedName("sage")
-    val sage: String? = null, // sage
-    @SerializedName("admin")
-    val admin: String, //admin 	是否是酷炫红名，如果是酷炫红名则userid为红名id
-    @SerializedName("status")
-    val status: String? = "n", //?
-    @SerializedName("replys")
-    val replys: List<Reply>? = null, //replys 	主页展示回复的帖子
-    @SerializedName("replyCount")
-    val replyCount: String? = null //replyCount 	总共有多少个回复
+    val sage: String = "0", // sage
+    val admin: String = "0", //admin 	是否是酷炫红名，如果是酷炫红名则userid为红名id
+    val status: String = "n", //
+    @Ignore var replys: List<Reply> = emptyList(), //replys 	主页展示回复的帖子
+    val replyCount: String = "0", //replyCount 	总共有多少个回复
+    var readingProgress: Int = 0, // 记录上次看到的进度
+    var lastUpdatedAt: Long = 0
 ) {
+    // Room uses this
+    constructor(
+        id: String,
+        fid: String,
+        category: String,
+        img: String,
+        ext: String,
+        now: String,
+        userid: String,
+        name: String,
+        email: String,
+        title: String,
+        content: String,
+        sage: String,
+        admin: String,
+        status: String,
+        replyCount: String,
+        readingProgress: Int,
+        lastUpdatedAt: Long
+    ) : this(
+        id,
+        fid,
+        "",
+        category,
+        img,
+        ext,
+        now,
+        userid,
+        name,
+        email,
+        title,
+        content,
+        sage,
+        admin,
+        status,
+        emptyList(),
+        replyCount,
+        readingProgress,
+        lastUpdatedAt
+    )
+
     // convert threadList to Reply
     fun toReply() = Reply(
         id = id,
@@ -55,7 +82,8 @@ data class Thread(
         now = now,
         content = content,
         img = img,
-        ext = ext
+        ext = ext,
+        page = 1
     )
 
     fun getImgUrl(): String {

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/Thread.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/Thread.kt
@@ -10,7 +10,6 @@ import com.squareup.moshi.JsonClass
 data class Thread(
     @PrimaryKey val id: String, //	该串的id
     var fid: String = "", //	该串的fid, 非时间线的串会被设置
-    @Ignore var forumName: String = "",// only used for displaying name
     var category: String = "",
     val img: String, //	该串的图片相对地址
     val ext: String, // 	该串图片的后缀
@@ -50,7 +49,6 @@ data class Thread(
     ) : this(
         id,
         fid,
-        "",
         category,
         img,
         ext,
@@ -86,7 +84,7 @@ data class Thread(
         page = 1
     )
 
-    fun getImgUrl(): String {
-        return img + ext
-    }
+    fun isDataComplete(): Boolean = (userid.isNotBlank() && now.isNotBlank())
+
+    fun getImgUrl() = (img + ext)
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CommunityDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CommunityDao.kt
@@ -1,14 +1,15 @@
 package com.laotoua.dawnislandk.data.local.dao
 
+import androidx.lifecycle.LiveData
 import androidx.room.*
 import com.laotoua.dawnislandk.data.local.Community
 
 @Dao
 interface CommunityDao {
-    @Query("SELECT * FROM community")
-    suspend fun getAll(): List<Community>
+    @Query("SELECT * FROM Community")
+    fun getAll(): LiveData<List<Community>>
 
-    @Query("SELECT * FROM community WHERE id==:id")
+    @Query("SELECT * FROM Community WHERE id==:id")
     suspend fun getCommunityById(id: String): Community
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -17,6 +18,6 @@ interface CommunityDao {
     @Delete
     suspend fun delete(community: Community)
 
-    @Query("DELETE FROM community")
+    @Query("DELETE FROM Community")
     fun nukeTable()
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CommunityDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CommunityDao.kt
@@ -9,7 +9,7 @@ interface CommunityDao {
     @Query("SELECT * FROM Community")
     fun getAll(): LiveData<List<Community>>
 
-    @Query("SELECT * FROM Community WHERE id==:id")
+    @Query("SELECT * FROM Community WHERE id=:id")
     suspend fun getCommunityById(id: String): Community
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/Converter.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/Converter.kt
@@ -1,18 +1,32 @@
 package com.laotoua.dawnislandk.data.local.dao
 
 import androidx.room.TypeConverter
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.laotoua.dawnislandk.data.local.Forum
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 
 class Converter {
+    private val moshi = Moshi.Builder().build()
     @TypeConverter
-    fun listToJson(value: String): List<Forum> {
-        return Gson().fromJson(value, object : TypeToken<List<Forum>>() {}.type)
+    fun jsonToList(value: String): List<Forum> {
+        val adapter: JsonAdapter<List<Forum>> = moshi.adapter(
+            Types.newParameterizedType(
+                List::class.java,
+                Forum::class.java
+            )
+        )
+        return adapter.fromJson(value)!!
     }
 
     @TypeConverter
-    fun jsonToList(list: List<Forum>): String {
-        return Gson().toJson(list)
+    fun listToJson(list: List<Forum>): String {
+        val adapter: JsonAdapter<List<Forum>> = moshi.adapter(
+            Types.newParameterizedType(
+                List::class.java,
+                Forum::class.java
+            )
+        )
+        return adapter.toJson(list)
     }
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CookieDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CookieDao.kt
@@ -6,10 +6,10 @@ import com.laotoua.dawnislandk.data.local.Cookie
 
 @Dao
 interface CookieDao {
-    @Query("SELECT * FROM cookie")
+    @Query("SELECT * FROM Cookie")
     suspend fun getAll(): List<Cookie>
 
-    @Query("SELECT * FROM cookie WHERE cookieHash==:cookieHash")
+    @Query("SELECT * FROM Cookie WHERE cookieHash==:cookieHash")
     suspend fun getCookieByUserHash(cookieHash: String): Cookie
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CookieDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/CookieDao.kt
@@ -9,7 +9,7 @@ interface CookieDao {
     @Query("SELECT * FROM Cookie")
     suspend fun getAll(): List<Cookie>
 
-    @Query("SELECT * FROM Cookie WHERE cookieHash==:cookieHash")
+    @Query("SELECT * FROM Cookie WHERE cookieHash=:cookieHash")
     suspend fun getCookieByUserHash(cookieHash: String): Cookie
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -30,6 +30,6 @@ interface CookieDao {
     @Delete
     suspend fun delete(cookie: Cookie)
 
-    @Query("DELETE FROM cookie")
+    @Query("DELETE FROM Cookie")
     fun nukeTable()
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/DawnDatabase.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/DawnDatabase.kt
@@ -1,43 +1,27 @@
 package com.laotoua.dawnislandk.data.local.dao
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.laotoua.dawnislandk.data.local.Community
 import com.laotoua.dawnislandk.data.local.Cookie
-
+import com.laotoua.dawnislandk.data.local.Reply
+import com.laotoua.dawnislandk.data.local.Thread
 
 // TODO: export Schema
-@Database(entities = [Community::class, Cookie::class], version = 1, exportSchema = false)
+@Database(
+    entities = [Community::class,
+        Cookie::class,
+        Reply::class,
+        Thread::class],
+    version = 1,
+    exportSchema = false
+)
 @TypeConverters(Converter::class)
 abstract class DawnDatabase : RoomDatabase() {
     abstract fun cookieDao(): CookieDao
     abstract fun communityDao(): CommunityDao
-
-    companion object {
-        // Singleton prevents multiple instances of database opening at the
-        // same time.
-        @Volatile
-        private var INSTANCE: DawnDatabase? = null
-
-        fun getDatabase(context: Context): DawnDatabase {
-            val tempInstance =
-                INSTANCE
-            if (tempInstance != null) {
-                return tempInstance
-            }
-            synchronized(this) {
-                val instance = Room.databaseBuilder(
-                    context.applicationContext,
-                    DawnDatabase::class.java,
-                    "dawn_database"
-                ).build()
-                INSTANCE = instance
-                return instance
-            }
-        }
-    }
+    abstract fun replyDao(): ReplyDao
+    abstract fun threadDao(): ThreadDao
 }
 

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ReplyDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ReplyDao.kt
@@ -1,0 +1,38 @@
+package com.laotoua.dawnislandk.data.local.dao
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.distinctUntilChanged
+import androidx.room.*
+import com.laotoua.dawnislandk.data.local.Reply
+import java.util.*
+
+@Dao
+interface ReplyDao {
+
+    @Query("SELECT * FROM Reply WHERE parentId=:parentId")
+    suspend fun findAllByParentId(parentId: String): List<Reply>
+
+    @Query("SELECT * FROM Reply WHERE parentId=:parentId AND page<=:page")
+    suspend fun findByParentIdUntilPage(parentId: String, page: Int): List<Reply>
+
+    @Query("SELECT * FROM Reply WHERE parentId=:parentId AND page=:page")
+    fun findPageByParentId(parentId: String, page: Int): LiveData<List<Reply>>
+
+    fun findDistinctPageByParentId(parentId: String, page: Int):
+            LiveData<List<Reply>> = findPageByParentId(parentId, page).distinctUntilChanged()
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(replyList: List<Reply>)
+
+    suspend fun insertAllWithTimeStamp(replyList: List<Reply>) {
+        val timestamp = Date().time
+        val listWithTimeStamps = replyList.apply { map { it.lastUpdatedAt = timestamp } }
+        insertAll(listWithTimeStamps)
+    }
+
+    @Delete
+    suspend fun delete(reply: Reply)
+
+    @Query("DELETE FROM Reply")
+    fun nukeTable()
+}

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ThreadDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ThreadDao.kt
@@ -1,0 +1,37 @@
+package com.laotoua.dawnislandk.data.local.dao
+
+import androidx.room.*
+import com.laotoua.dawnislandk.data.local.Thread
+import java.util.*
+
+@Dao
+interface ThreadDao {
+    @Query("SELECT * FROM Thread")
+    suspend fun getAll(): List<Thread>
+
+    @Query("SELECT * FROM Thread WHERE id==:id")
+    suspend fun getThreadById(id: String): Thread
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(thread: Thread)
+
+    suspend fun insertWithTimeStamp(thread: Thread) {
+        thread.lastUpdatedAt = Date().time
+        insert(thread)
+    }
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(threadList: List<Thread>)
+
+    suspend fun insertAllWithTimeStamp(threadList: List<Thread>) {
+        val timestamp = Date().time
+        val listWithTimeStamps = threadList.apply { map { it.lastUpdatedAt = timestamp } }
+        insertAll(listWithTimeStamps)
+    }
+
+    @Delete
+    suspend fun delete(thread: Thread)
+
+    @Query("DELETE FROM Thread")
+    fun nukeTable()
+}

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ThreadDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ThreadDao.kt
@@ -1,5 +1,7 @@
 package com.laotoua.dawnislandk.data.local.dao
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.distinctUntilChanged
 import androidx.room.*
 import com.laotoua.dawnislandk.data.local.Thread
 import java.util.*
@@ -10,7 +12,10 @@ interface ThreadDao {
     suspend fun getAll(): List<Thread>
 
     @Query("SELECT * FROM Thread WHERE id=:id")
-    suspend fun getThreadById(id: String): Thread
+    fun findThreadById(id: String): LiveData<Thread>
+
+    fun findDistinctThreadById(id: String): LiveData<Thread> =
+        findThreadById(id).distinctUntilChanged()
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(thread: Thread)

--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ThreadDao.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/dao/ThreadDao.kt
@@ -9,7 +9,7 @@ interface ThreadDao {
     @Query("SELECT * FROM Thread")
     suspend fun getAll(): List<Thread>
 
-    @Query("SELECT * FROM Thread WHERE id==:id")
+    @Query("SELECT * FROM Thread WHERE id=:id")
     suspend fun getThreadById(id: String): Thread
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/laotoua/dawnislandk/data/remote/NMBServiceClient.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/remote/NMBServiceClient.kt
@@ -1,10 +1,11 @@
 package com.laotoua.dawnislandk.data.remote
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import com.laotoua.dawnislandk.data.local.Community
 import com.laotoua.dawnislandk.data.local.Reply
 import com.laotoua.dawnislandk.data.local.Thread
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -15,25 +16,36 @@ import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
-
 class NMBServiceClient @Inject constructor(private val service: NMBService) {
 
-    private val parser = Gson()
+    private val moshi: Moshi = Moshi.Builder().build()
 
     private val parseCommunities: (String) -> List<Community> = { response ->
-        parser.fromJson(response, object : TypeToken<List<Community>>() {}.type)
+        val adapter: JsonAdapter<List<Community>> = moshi.adapter(
+            Types.newParameterizedType(
+                List::class.java,
+                Community::class.java
+            )
+        )
+        adapter.fromJson(response)!!
     }
 
     private val parseThreads: (String) -> List<Thread> = { response ->
-        parser.fromJson(response, object : TypeToken<List<Thread>>() {}.type)
+        val adapter: JsonAdapter<List<Thread>> = moshi.adapter(
+            Types.newParameterizedType(
+                List::class.java,
+                Thread::class.java
+            )
+        )
+        adapter.fromJson(response)!!
     }
 
     private val parseReplys: (String) -> Thread = { response ->
-        parser.fromJson(response, Thread::class.java)
+        moshi.adapter(Thread::class.java).fromJson(response)!!
     }
 
     private val parseQuote: (String) -> Reply = { response ->
-        parser.fromJson(response, Reply::class.java)
+        moshi.adapter(Reply::class.java).fromJson(response)!!
     }
 
     suspend fun getCommunities(): APIDataResponse<List<Community>> {

--- a/app/src/main/java/com/laotoua/dawnislandk/data/repository/CommunityRepository.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/repository/CommunityRepository.kt
@@ -1,36 +1,52 @@
 package com.laotoua.dawnislandk.data.repository
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.liveData
 import com.laotoua.dawnislandk.data.local.Community
 import com.laotoua.dawnislandk.data.local.dao.CommunityDao
+import com.laotoua.dawnislandk.data.remote.APIErrorDataResponse
 import com.laotoua.dawnislandk.data.remote.NMBServiceClient
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.Dispatchers
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class CommunityRepository @Inject constructor(
     private val webService: NMBServiceClient,
     private val dao: CommunityDao
 ) {
+    val communityList: LiveData<List<Community>> = liveData(Dispatchers.IO) {
+        Timber.d("Loading communities")
+        val local = dao.getAll()
+        emitSource(local)
+        matchRemoteData(local)
+    }
 
-    fun getCommunities(remoteDataOnly: Boolean): Flow<DataResource<List<Community>>> = flow {
-        var localList: List<Community>? = null
-        if (!remoteDataOnly) {
-            localList = dao.getAll()
-            Timber.i("Loaded ${localList.size} communities from db")
-            emit(DataResource.create(localList))
-        }
+    private val mErrorMsg = MutableLiveData<String>()
+    val errorMsg: LiveData<String> get() = mErrorMsg
 
-        DataResource.create(webService.getCommunities()).run {
-            if (this is DataResource.Success) {
-                if (!data.isNullOrEmpty() && data != localList) {
-                    Timber.i("Community list has changed. updating...")
-                    emit(this)
-                    dao.insertAll(data)
-                } else {
-                    Timber.i("Community list is the same as Db. Reusing...")
-                }
-            }
+    private suspend fun getRemoteData(): List<Community> {
+        webService.getCommunities().run {
+            if (this is APIErrorDataResponse) mErrorMsg.postValue(message)
+            return data ?: emptyList()
         }
     }
+
+    private suspend fun matchRemoteData(
+        local: LiveData<List<Community>>,
+        remoteDataOnly: Boolean = false
+    ) {
+        val remote = getRemoteData()
+        if (remote.isNotEmpty() && (remote != local.value || remoteDataOnly)) {
+            Timber.d("Remote data differs from local data or forced refresh. Updating...")
+            dao.insertAll(remote)
+        }
+    }
+
+    suspend fun refresh() {
+        matchRemoteData(communityList, true)
+    }
+
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/repository/DataResource.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/repository/DataResource.kt
@@ -16,6 +16,8 @@ sealed class DataResource<T>(
         }
 
         fun <T> create(data: T): DataResource<T> = Success("Room data", data)
+
+        fun <T> create(message: String, data: T): DataResource<T> = Success(message, data)
     }
 
     class Success<T>(message: String, data: T) : DataResource<T>(message, data)

--- a/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
@@ -1,0 +1,169 @@
+package com.laotoua.dawnislandk.data.repository
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.liveData
+import com.laotoua.dawnislandk.DawnApp
+import com.laotoua.dawnislandk.data.local.Reply
+import com.laotoua.dawnislandk.data.local.Thread
+import com.laotoua.dawnislandk.data.local.dao.ReplyDao
+import com.laotoua.dawnislandk.data.local.dao.ThreadDao
+import com.laotoua.dawnislandk.data.remote.*
+import com.laotoua.dawnislandk.util.EventPayload
+import com.laotoua.dawnislandk.util.LoadingStatus
+import com.laotoua.dawnislandk.util.SingleLiveEvent
+import kotlinx.coroutines.Dispatchers
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReplyRepository @Inject constructor(
+    private val webService: NMBServiceClient,
+    private val replyDao: ReplyDao,
+    private val threadDao: ThreadDao
+) {
+    var currentThreadId: String = ""
+    private var currentThread: Thread? = null
+    private val replyMap = sortedMapOf<Int, LiveData<List<Reply>>>()
+    private val adMap = sortedMapOf<Int, Reply>()
+    private var maxReply = 0
+    var po: String = ""
+    val maxPage get() = 1.coerceAtLeast(kotlin.math.ceil(maxReply.toDouble() / 19).toInt())
+    val loadingStatus = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
+    val addFeedResponse = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
+
+    /** When thread has 0 reply, this triggers VM to show an empty page
+     *
+     */
+    val emptyPage = MutableLiveData<Boolean>()
+
+    fun attachAdAndHead(list: List<Reply>, page: Int) = mutableListOf<Reply>().apply {
+        /**
+         *  w. cookie, responses have 20 reply w. ad, or 19 reply w/o ad
+         *  w/o cookie, always have 20 reply w. ad
+         *  MARK full page for next page load
+         *  *** FIRST PAGE also has thread head
+         */
+        if (page == 1) add(currentThread!!.toReply())
+        adMap[page]?.let { add(it) }
+        addAll(list)
+    }
+
+    fun setThread(f: Thread) {
+        if (f.id == currentThreadId) return
+        Timber.i("Thread has changed... Clearing old data")
+        clearCache()
+        Timber.i("Setting new Thread: ${f.id}")
+        currentThreadId = f.id
+        currentThread = f
+        po = f.userid
+        emptyPage.value = false
+    }
+
+    private fun clearCache() {
+        emptyPage.value = false
+        replyMap.clear()
+    }
+
+    fun checkFullPage(page: Int): Boolean = (replyMap[page]?.value?.size == 19)
+
+    private fun setLoadingStatus(status: LoadingStatus, message: String? = null) {
+        loadingStatus.postValue(SingleLiveEvent.create(status, message))
+    }
+
+    fun getLiveDataOnPage(page: Int): LiveData<List<Reply>> {
+        if (replyMap[page] == null) replyMap[page] = getLivePage(page)
+        return replyMap[page]!!
+    }
+
+    private fun getLivePage(page: Int) = liveData(Dispatchers.IO) {
+        Timber.d("Querying data for Thread $currentThreadId on $page")
+        setLoadingStatus(LoadingStatus.LOADING)
+        emitSource(getLocalData(page))
+        getServerData(page)
+    }
+
+    private fun getLocalData(page: Int): LiveData<List<Reply>> =
+        replyDao.findDistinctPageByParentId(currentThreadId, page)
+
+    suspend fun getServerData(page: Int) {
+        Timber.d("Querying remote data for Thread $currentThreadId on $page")
+        webService.getReplys(
+            DawnApp.applicationDataStore.firstCookieHash,
+            currentThreadId,
+            page
+        ).run {
+            when (this) {
+                is APISuccessDataResponse -> convertServerData(data, page)
+                is APIErrorDataResponse -> {
+                    Timber.e(message)
+                    setLoadingStatus(LoadingStatus.FAILED, "无法读取串回复...\n$message")
+                }
+                else -> {
+                    Timber.e("Unhandled response $this")
+                }
+            }
+        }
+    }
+
+    private suspend fun convertServerData(data: Thread, page: Int) {
+        // update current thread with latest info
+        currentThread = data
+
+        maxReply = data.replyCount.toInt()
+        data.replys.map {
+            it.page = page
+            it.parentId = currentThreadId
+        }
+
+        // handle Ad
+        data.replys.firstOrNull { !it.isNotAd() }?.let {
+            adMap[page] = it
+        }
+        val noAd = data.replys.filter { it.isNotAd() }
+        if (page == 1 && noAd.isEmpty()) {
+            emptyPage.postValue(true)
+            return
+        }
+        if (noAd.isEmpty() || (replyMap[page]?.value == noAd && page == maxPage)) {
+            setLoadingStatus(LoadingStatus.NODATA)
+            return
+        }
+        Timber.d("Updating ${noAd.size} rows for $currentThreadId on $page")
+        saveReplys(noAd)
+    }
+
+    // DO NOT SAVE ADS
+    private suspend fun saveReplys(replys: List<Reply>) = replyDao.insertAll(replys)
+
+    // TODO: do not send request if subscribe already
+    suspend fun addFeed(uuid: String, id: String) {
+        Timber.i("Adding Feed $id")
+        webService.addFeed(uuid, id).run {
+            when (this) {
+                is APISuccessMessageResponse -> {
+                    if (messageType == MessageType.String) {
+                        addFeedResponse.postValue(
+                            SingleLiveEvent.create(
+                                LoadingStatus.SUCCESS,
+                                message
+                            )
+                        )
+                    } else {
+                        Timber.e(message)
+                    }
+                }
+                else -> {
+                    Timber.e("Response type: ${this.javaClass.simpleName}\n $message")
+                    addFeedResponse.postValue(
+                        SingleLiveEvent.create(
+                            LoadingStatus.FAILED,
+                            "订阅失败...是不是已经订阅了呢?"
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
@@ -15,9 +15,7 @@ import com.laotoua.dawnislandk.util.SingleLiveEvent
 import kotlinx.coroutines.Dispatchers
 import timber.log.Timber
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class ReplyRepository @Inject constructor(
     private val webService: NMBServiceClient,
     private val replyDao: ReplyDao,
@@ -68,7 +66,7 @@ class ReplyRepository @Inject constructor(
 
     fun checkFullPage(page: Int): Boolean = (replyMap[page]?.value?.size == 19)
 
-    private fun setLoadingStatus(status: LoadingStatus, message: String? = null) {
+    fun setLoadingStatus(status: LoadingStatus, message: String? = null) {
         loadingStatus.postValue(SingleLiveEvent.create(status, message))
     }
 
@@ -126,8 +124,14 @@ class ReplyRepository @Inject constructor(
             emptyPage.postValue(true)
             return
         }
-        if (noAd.isEmpty() || (replyMap[page]?.value == noAd && page == maxPage)) {
-            setLoadingStatus(LoadingStatus.NODATA)
+        /**
+         *  On the last page, show NO DATA to indicate footer load end;
+         *  When entering to a thread with cached data, refresh header is showing,
+         *  set LoadingStatus to Success to hide the header
+         */
+        if (noAd.isEmpty() || replyMap[page]?.value == noAd) {
+            if (page == maxPage) setLoadingStatus(LoadingStatus.NODATA)
+            else setLoadingStatus(LoadingStatus.SUCCESS)
             return
         }
         Timber.d("Updating ${noAd.size} rows for $currentThreadId on $page")

--- a/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
@@ -1,6 +1,7 @@
 package com.laotoua.dawnislandk.data.repository
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.liveData
 import com.laotoua.dawnislandk.DawnApp
@@ -8,67 +9,78 @@ import com.laotoua.dawnislandk.data.local.Reply
 import com.laotoua.dawnislandk.data.local.Thread
 import com.laotoua.dawnislandk.data.local.dao.ReplyDao
 import com.laotoua.dawnislandk.data.local.dao.ThreadDao
-import com.laotoua.dawnislandk.data.remote.*
+import com.laotoua.dawnislandk.data.remote.APISuccessDataResponse
+import com.laotoua.dawnislandk.data.remote.APISuccessMessageResponse
+import com.laotoua.dawnislandk.data.remote.MessageType
+import com.laotoua.dawnislandk.data.remote.NMBServiceClient
 import com.laotoua.dawnislandk.util.EventPayload
 import com.laotoua.dawnislandk.util.LoadingStatus
 import com.laotoua.dawnislandk.util.SingleLiveEvent
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.collections.set
 
+// TODO: Singleton creates problem when we want multiple reply fragment exist at the same time
+@Singleton
 class ReplyRepository @Inject constructor(
     private val webService: NMBServiceClient,
     private val replyDao: ReplyDao,
     private val threadDao: ThreadDao
 ) {
     var currentThreadId: String = ""
-    private var currentThread: Thread? = null
+    var currentThread: LiveData<Thread>? = null
     private val replyMap = sortedMapOf<Int, LiveData<List<Reply>>>()
     private val adMap = sortedMapOf<Int, Reply>()
     private var maxReply = 0
-    var po: String = ""
+
     val maxPage get() = 1.coerceAtLeast(kotlin.math.ceil(maxReply.toDouble() / 19).toInt())
     val loadingStatus = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
     val addFeedResponse = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
 
+    private var downloadJob: Job? = null
+
     /** When thread has 0 reply, this triggers VM to show an empty page
      *
      */
-    val emptyPage = MutableLiveData<Boolean>()
+    private var emptyPage = MutableLiveData<Boolean>()
 
-    fun attachAdAndHead(list: List<Reply>, page: Int) = mutableListOf<Reply>().apply {
-        /**
-         *  w. cookie, responses have 20 reply w. ad, or 19 reply w/o ad
-         *  w/o cookie, always have 20 reply w. ad
-         *  MARK full page for next page load
-         *  *** FIRST PAGE also has thread head
-         */
-//        if(currentThread!!.isDataComplete().not()) return@apply
-        if (page == 1 && currentThread != null && currentThread!!.isDataComplete()) add(
-            currentThread!!.toReply()
-        )
-        adMap[page]?.let { add(it) }
-        addAll(list)
-    }
 
-    // TODO: get header
-    fun setThread(id: String) {
+    fun getAd(page: Int): Reply? = adMap[page]
+
+    fun setThreadId(id: String) {
         if (id == currentThreadId) return
         Timber.i("Thread has changed... Clearing old data")
         clearCache()
         Timber.i("Setting new Thread: $id")
         currentThreadId = id
-//        currentThread = f
-//        po = f.userid
-        emptyPage.value = false
+        setThread(id)
+    }
+
+    private fun setThread(id: String) {
+        currentThread = threadDao.findDistinctThreadById(id)
     }
 
     private fun clearCache() {
-        emptyPage.value = false
         replyMap.clear()
+        adMap.clear()
+        downloadJob?.cancel()
+        downloadJob = null
+        emptyPage = MutableLiveData<Boolean>()
     }
 
-    fun checkFullPage(page: Int): Boolean = (replyMap[page]?.value?.size == 19)
+    /**
+     *  w. cookie, responses have 20 reply w. ad, or 19 reply w/o ad
+     *  w/o cookie, always have 20 reply w. ad
+     *  *** here DB only store nonAd data
+     *  *** FIRST PAGE also has thread head
+     */
+    fun checkFullPage(page: Int): Boolean =
+        (replyMap[page]?.value?.size == (if (page == 1) 20 else 19))
 
     fun setLoadingStatus(status: LoadingStatus, message: String? = null) {
         loadingStatus.postValue(SingleLiveEvent.create(status, message))
@@ -83,27 +95,58 @@ class ReplyRepository @Inject constructor(
         Timber.d("Querying data for Thread $currentThreadId on $page")
         setLoadingStatus(LoadingStatus.LOADING)
         emitSource(getLocalData(page))
-        getServerData(page)
+        downloadJob = getServerData(page)
     }
 
-    private fun getLocalData(page: Int): LiveData<List<Reply>> =
-        replyDao.findDistinctPageByParentId(currentThreadId, page)
-
-    suspend fun getServerData(page: Int) {
-        Timber.d("Querying remote data for Thread $currentThreadId on $page")
-        webService.getReplys(
-            DawnApp.applicationDataStore.firstCookieHash,
-            currentThreadId,
-            page
-        ).run {
-            when (this) {
-                is APISuccessDataResponse -> convertServerData(data, page)
-                is APIErrorDataResponse -> {
-                    Timber.e(message)
-                    setLoadingStatus(LoadingStatus.FAILED, "无法读取串回复...\n$message")
+    /**
+     * insert Header to first page
+     */
+    private fun getLiveFirstPage(head: LiveData<Thread>, livePage: LiveData<List<Reply>>) =
+        MediatorLiveData<List<Reply>>().apply {
+            var header: Reply? = null
+            var page: List<Reply>? = null
+            addSource(head) {
+                // catch pending value (null DB query result)
+                if (it == null) return@addSource
+                header = it.toReply()
+                // wait for other source finish loading and set together
+                page?.let { list -> if (list.isNotEmpty()) value = listOf(header!!).plus(list) }
+            }
+            addSource(livePage) { list ->
+                // catch pending value (null DB query result)
+                if (list == null) return@addSource
+                page = list
+                // wait for other source finish loading and set together
+                header?.let { if (list.isNotEmpty()) value = listOf(it).plus(list) }
+            }
+            addSource(emptyPage) {
+                value = mutableListOf<Reply>().apply {
+                    header?.let { head -> add(head) }
+                    page?.let { list -> addAll(list) }
                 }
-                else -> {
-                    Timber.e("Unhandled response $this")
+            }
+        }
+
+    private fun getLocalData(page: Int): LiveData<List<Reply>> {
+        val livePage = replyDao.findDistinctPageByParentId(currentThreadId, page)
+        return if (page == 1) getLiveFirstPage(currentThread!!, livePage)
+        else livePage
+    }
+
+    suspend fun getServerData(page: Int): Job = coroutineScope {
+        launch {
+            Timber.d("Querying remote data for Thread $currentThreadId on $page")
+            webService.getReplys(
+                DawnApp.applicationDataStore.firstCookieHash,
+                currentThreadId,
+                page
+            ).run {
+                if (this is APISuccessDataResponse) convertServerData(data, page)
+                else {
+                    if (downloadJob != null) {
+                        Timber.e(message)
+                        setLoadingStatus(LoadingStatus.FAILED, "无法读取串回复...\n$message")
+                    }
                 }
             }
         }
@@ -111,7 +154,7 @@ class ReplyRepository @Inject constructor(
 
     private suspend fun convertServerData(data: Thread, page: Int) {
         // update current thread with latest info
-        currentThread = data
+        threadDao.insert(data)
 
         maxReply = data.replyCount.toInt()
         data.replys.map {
@@ -129,15 +172,18 @@ class ReplyRepository @Inject constructor(
             return
         }
         /**
-         *  On the last page, show NO DATA to indicate footer load end;
+         *  On the first or last page, show NO DATA to indicate footer load end;
          *  When entering to a thread with cached data, refresh header is showing,
          *  set LoadingStatus to Success to hide the header
          */
-        if (noAd.isEmpty() || replyMap[page]?.value == noAd) {
+        if (noAd.isEmpty() || (replyMap[page]?.value == noAd) ||
+            (page == 1 && replyMap[page]?.value?.drop(1) == noAd)
+        ) {
             if (page == maxPage) setLoadingStatus(LoadingStatus.NODATA)
             else setLoadingStatus(LoadingStatus.SUCCESS)
             return
         }
+
         Timber.d("Updating ${noAd.size} rows for $currentThreadId on $page")
         saveReplys(noAd)
     }
@@ -149,28 +195,25 @@ class ReplyRepository @Inject constructor(
     suspend fun addFeed(uuid: String, id: String) {
         Timber.i("Adding Feed $id")
         webService.addFeed(uuid, id).run {
-            when (this) {
-                is APISuccessMessageResponse -> {
-                    if (messageType == MessageType.String) {
-                        addFeedResponse.postValue(
-                            SingleLiveEvent.create(
-                                LoadingStatus.SUCCESS,
-                                message
-                            )
-                        )
-                    } else {
-                        Timber.e(message)
-                    }
-                }
-                else -> {
-                    Timber.e("Response type: ${this.javaClass.simpleName}\n $message")
+            if (this is APISuccessMessageResponse) {
+                if (messageType == MessageType.String) {
                     addFeedResponse.postValue(
                         SingleLiveEvent.create(
-                            LoadingStatus.FAILED,
-                            "订阅失败...是不是已经订阅了呢?"
+                            LoadingStatus.SUCCESS,
+                            message
                         )
                     )
+                } else {
+                    Timber.e(message)
                 }
+            } else {
+                Timber.e("Response type: ${this.javaClass.simpleName}\n $message")
+                addFeedResponse.postValue(
+                    SingleLiveEvent.create(
+                        LoadingStatus.FAILED,
+                        "订阅失败...是不是已经订阅了呢?"
+                    )
+                )
             }
         }
     }

--- a/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/repository/ReplyRepository.kt
@@ -43,19 +43,23 @@ class ReplyRepository @Inject constructor(
          *  MARK full page for next page load
          *  *** FIRST PAGE also has thread head
          */
-        if (page == 1) add(currentThread!!.toReply())
+//        if(currentThread!!.isDataComplete().not()) return@apply
+        if (page == 1 && currentThread != null && currentThread!!.isDataComplete()) add(
+            currentThread!!.toReply()
+        )
         adMap[page]?.let { add(it) }
         addAll(list)
     }
 
-    fun setThread(f: Thread) {
-        if (f.id == currentThreadId) return
+    // TODO: get header
+    fun setThread(id: String) {
+        if (id == currentThreadId) return
         Timber.i("Thread has changed... Clearing old data")
         clearCache()
-        Timber.i("Setting new Thread: ${f.id}")
-        currentThreadId = f.id
-        currentThread = f
-        po = f.userid
+        Timber.i("Setting new Thread: $id")
+        currentThreadId = id
+//        currentThread = f
+//        po = f.userid
         emptyPage.value = false
     }
 

--- a/app/src/main/java/com/laotoua/dawnislandk/di/DatabaseModule.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/di/DatabaseModule.kt
@@ -2,9 +2,7 @@ package com.laotoua.dawnislandk.di
 
 import android.content.Context
 import androidx.room.Room
-import com.laotoua.dawnislandk.data.local.dao.CommunityDao
-import com.laotoua.dawnislandk.data.local.dao.CookieDao
-import com.laotoua.dawnislandk.data.local.dao.DawnDatabase
+import com.laotoua.dawnislandk.data.local.dao.*
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -36,5 +34,19 @@ object DatabaseModule {
     @Singleton
     fun provideCookieDao(dawnDatabase: DawnDatabase): CookieDao {
         return dawnDatabase.cookieDao()
+    }
+
+    @JvmStatic
+    @Provides
+    @Singleton
+    fun provideReplyDao(dawnDatabase: DawnDatabase): ReplyDao {
+        return dawnDatabase.replyDao()
+    }
+
+    @JvmStatic
+    @Provides
+    @Singleton
+    fun provideThreadDao(dawnDatabase: DawnDatabase): ThreadDao {
+        return dawnDatabase.threadDao()
     }
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/di/NMBNetworkModule.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/di/NMBNetworkModule.kt
@@ -5,7 +5,9 @@ import com.laotoua.dawnislandk.data.remote.NMBServiceClient
 import com.laotoua.dawnislandk.util.Constants
 import dagger.Module
 import dagger.Provides
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -14,10 +16,18 @@ object NMBNetworkModule {
     @JvmStatic
     @Provides
     @Singleton
-    fun provideNMBService(): NMBService = Retrofit.Builder()
-        .baseUrl(Constants.baseCDN)
-        .build()
-        .create(NMBService::class.java)
+    fun provideNMBService(): NMBService {
+        val okHttpClient = OkHttpClient().newBuilder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+        return Retrofit.Builder()
+            .baseUrl(Constants.baseCDN)
+            .client(okHttpClient)
+            .build()
+            .create(NMBService::class.java)
+    }
 
     @JvmStatic
     @Provides

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/CommunityViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/CommunityViewModel.kt
@@ -1,16 +1,13 @@
 package com.laotoua.dawnislandk.screens
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.laotoua.dawnislandk.data.local.Community
 import com.laotoua.dawnislandk.data.repository.CommunityRepository
-import com.laotoua.dawnislandk.data.repository.DataResource
 import com.laotoua.dawnislandk.util.EventPayload
 import com.laotoua.dawnislandk.util.LoadingStatus
 import com.laotoua.dawnislandk.util.SingleLiveEvent
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -18,39 +15,17 @@ import javax.inject.Inject
 class CommunityViewModel @Inject constructor(private val communityRepository: CommunityRepository) :
     ViewModel() {
 
-    private var _communityList = MutableLiveData<List<Community>>()
-    val communityList: LiveData<List<Community>>
-        get() = _communityList
+    val communityList get() = communityRepository.communityList
 
-    private var _loadingStatus = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
-    val loadingStatus: LiveData<SingleLiveEvent<EventPayload<Nothing>>>
-        get() = _loadingStatus
-
-    init {
-        getCommunities()
-    }
-
-    private fun getCommunities(remoteDataOnly: Boolean = false) {
-        viewModelScope.launch {
-            communityRepository.getCommunities(remoteDataOnly).collect {
-                Timber.d("collecting flow")
-                when (it) {
-                    is DataResource.Error -> {
-                        Timber.e(it.message)
-                        _loadingStatus.postValue(
-                            SingleLiveEvent.create(
-                                LoadingStatus.FAILED,
-                                "无法读取板块列表...\n${it.message}"
-                            )
-                        )
-                    }
-                    is DataResource.Success -> {
-                        if (it.data!!.isNotEmpty()) _communityList.postValue(it.data)
-                    }
-                }
-            }
+    val loadingStatus: LiveData<SingleLiveEvent<EventPayload<Nothing>>> =
+        Transformations.map(communityRepository.errorMsg) { message ->
+            Timber.e(message)
+            SingleLiveEvent.create(
+                LoadingStatus.FAILED,
+                "无法读取板块列表...\n${message}",
+                null
+            )
         }
-    }
 
     fun getForumNameMapping(): Map<String, String> {
         return communityList.value?.flatMap { it.forums }?.associateBy(
@@ -59,7 +34,7 @@ class CommunityViewModel @Inject constructor(private val communityRepository: Co
     }
 
     fun refresh() {
-        getCommunities(true)
+        viewModelScope.launch { communityRepository.refresh() }
     }
 
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/MainActivity.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/MainActivity.kt
@@ -66,6 +66,7 @@ class MainActivity : DaggerAppCompatActivity(), QuickNodeAdapter.ForumClickListe
         binding.forumContainer.adapter = mAdapter
 
         communityVM.communityList.observe(this, Observer {
+            if (it.isNullOrEmpty()) return@Observer
             mAdapter.setData(it)
             Timber.i("Loaded ${it.size} communities to Adapter")
             // TODO: set default forum

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/MainActivity.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/MainActivity.kt
@@ -69,9 +69,9 @@ class MainActivity : DaggerAppCompatActivity(), QuickNodeAdapter.ForumClickListe
             if (it.isNullOrEmpty()) return@Observer
             mAdapter.setData(it)
             Timber.i("Loaded ${it.size} communities to Adapter")
+            sharedVM.setForumNameMapping(communityVM.getForumNameMapping())
             // TODO: set default forum
             sharedVM.setForum(it[0].forums[0])
-            sharedVM.setForumNameMapping(communityVM.getForumNameMapping())
         })
 
         communityVM.loadingStatus.observe(this, Observer {

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/PagerFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/PagerFragment.kt
@@ -97,10 +97,10 @@ class PagerFragment : DaggerFragment() {
             .setIndicatorStyle(IndicatorStyle.CIRCLE)
             .setupWithViewPager(binding.viewPager)
 
-        sharedVM.selectedForum.observe(viewLifecycleOwner, Observer {
-            if (mForumId != it.id) {
+        sharedVM.selectedForumId.observe(viewLifecycleOwner, Observer {
+            if (mForumId != it) {
                 binding.viewPager.currentItem = 0
-                mForumId = it.id
+                mForumId = it
             }
         })
 

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/SharedViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/SharedViewModel.kt
@@ -8,41 +8,38 @@ import com.laotoua.dawnislandk.data.local.Thread
 import timber.log.Timber
 
 class SharedViewModel : ViewModel() {
-    private var _selectedForum = MutableLiveData<Forum>()
-    val selectedForum: LiveData<Forum> get() = _selectedForum
-    private var _selectedThread = MutableLiveData<Thread>()
-    val selectedThread: LiveData<Thread> get() = _selectedThread
+    private var _selectedForumId = MutableLiveData<String>()
+    val selectedForumId: LiveData<String> get() = _selectedForumId
+    private var _selectedThreadId = MutableLiveData<String>()
+    val selectedThreadId: LiveData<String> get() = _selectedThreadId
+    private var selectedThreadFid: String = "-1"
 
     private var forumNameMapping = mapOf<String, String>()
 
     fun setForum(f: Forum) {
-        Timber.i("set forum to id: ${f.id}")
-        _selectedForum.postValue(f)
+        Timber.d("Setting forum to id: ${f.id}")
+        _selectedForumId.value = f.id
     }
 
     fun setThread(t: Thread) {
-        Timber.i("set thread to id: ${t.id}")
-        _selectedThread.postValue(t)
+        Timber.d("Setting thread to ${t.id} and its fid to ${t.fid}")
+        selectedThreadFid = t.fid
+        _selectedThreadId.value = t.id
     }
 
     fun setForumNameMapping(map: Map<String, String>) {
-        this.forumNameMapping = map
+        forumNameMapping = map
     }
 
-    fun getForumNameMapping(): Map<String, String> {
-        return forumNameMapping
-    }
+    fun getForumNameMapping(): Map<String, String> = forumNameMapping
 
-    fun getForumDisplayName(id: String): String {
-        return forumNameMapping[id] ?: ""
-    }
+    fun getForumDisplayName(id: String): String = forumNameMapping[id] ?: ""
 
-    fun getCurrentForumDisplayName(): String {
-        return getForumDisplayName(selectedThread.value?.fid!!)
-    }
+    fun getSelectedThreadForumName(): String = getForumDisplayName(selectedThreadFid)
 
     fun getForumIdByName(name: String): String {
-        return forumNameMapping.filter { (_, value) -> value == name }.keys.first()
+        return forumNameMapping.filterValues { it == name }.keys.first()
     }
+
 
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/adapters/QuickAdapter.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/adapters/QuickAdapter.kt
@@ -4,12 +4,10 @@ import android.graphics.Color
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
-import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import com.chad.library.adapter.base.BaseQuickAdapter
-import com.chad.library.adapter.base.loadmore.BaseLoadMoreView
 import com.chad.library.adapter.base.module.LoadMoreModule
 import com.chad.library.adapter.base.util.getItemView
 import com.chad.library.adapter.base.viewholder.BaseViewHolder
@@ -29,8 +27,8 @@ import timber.log.Timber
 
 
 // TODO: handle no new data exception
-class QuickAdapter(private val layoutResId: Int) :
-    BaseQuickAdapter<Any, BaseViewHolder>(layoutResId, ArrayList()),
+class QuickAdapter<T>(private val layoutResId: Int) :
+    BaseQuickAdapter<T, BaseViewHolder>(layoutResId, mutableListOf<T>()),
     LoadMoreModule {
 
     private lateinit var sharedViewModel: SharedViewModel
@@ -68,9 +66,9 @@ class QuickAdapter(private val layoutResId: Int) :
     /** default handler for recyclerview item
      *
      */
-    override fun convert(holder: BaseViewHolder, item: Any) {
+    override fun convert(holder: BaseViewHolder, item: T) {
         if (layoutResId == R.layout.list_item_thread && item is Thread) {
-            holder.convertThread(item, sharedViewModel.getForumDisplayName(item.fid!!))
+            holder.convertThread(item, sharedViewModel.getForumDisplayName(item.fid))
         } else if (layoutResId == R.layout.list_item_reply && item is Reply) {
             holder.convertReply(item, po)
         } else if (layoutResId == R.layout.list_item_trend && item is Trend) {
@@ -84,16 +82,15 @@ class QuickAdapter(private val layoutResId: Int) :
         }
     }
 
-    override fun convert(holder: BaseViewHolder, item: Any, payloads: List<Any>) {
+    override fun convert(holder: BaseViewHolder, item: T, payloads: List<Any>) {
         if (layoutResId == R.layout.list_item_thread && item is Thread) {
             holder.convertThreadWithPayload(
                 payloads.first() as Payload.ThreadPayload,
-                sharedViewModel.getForumDisplayName(item.fid!!)
+                sharedViewModel.getForumDisplayName(item.fid)
             )
         } else if (layoutResId == R.layout.list_item_reply && item is Reply) {
             holder.convertReplyWithPayload(payloads.first() as Payload.ReplyPayload)
         } else {
-            Timber.e("unhandled payload conversion")
             throw Exception("unhandled payload conversion")
         }
     }
@@ -128,7 +125,7 @@ class QuickAdapter(private val layoutResId: Int) :
     }
 
     private fun BaseViewHolder.convertReply(item: Reply, po: String) {
-        convertUserId(item.userid, item.admin!!, po)
+        convertUserId(item.userid, item.admin, po)
         convertTimeStamp(item.now)
         convertSage(item.sage)
         convertImage(item.img, item.ext)
@@ -257,7 +254,7 @@ class QuickAdapter(private val layoutResId: Int) :
         }
     }
 
-    private class DiffItemCallback : DiffUtil.ItemCallback<Any>() {
+    private class DiffItemCallback<T> : DiffUtil.ItemCallback<T>() {
 
         /**
          * 判断是否是同一个item
@@ -267,8 +264,8 @@ class QuickAdapter(private val layoutResId: Int) :
          * @return
          */
         override fun areItemsTheSame(
-            oldItem: Any,
-            newItem: Any
+            oldItem: T,
+            newItem: T
         ): Boolean {
             return when {
                 (oldItem is Thread && newItem is Thread) -> oldItem.id == newItem.id && oldItem.fid == newItem.fid
@@ -292,8 +289,8 @@ class QuickAdapter(private val layoutResId: Int) :
          * @return
          */
         override fun areContentsTheSame(
-            oldItem: Any,
-            newItem: Any
+            oldItem: T,
+            newItem: T
         ): Boolean {
             return when {
                 (oldItem is Thread && newItem is Thread) -> {
@@ -328,8 +325,8 @@ class QuickAdapter(private val layoutResId: Int) :
          * @return Payload info. if return null, the entire item will be refreshed.
          */
         override fun getChangePayload(
-            oldItem: Any,
-            newItem: Any
+            oldItem: T,
+            newItem: T
         ): Any? {
             return when {
                 (oldItem is Thread && newItem is Thread) -> {
@@ -369,7 +366,7 @@ class QuickAdapter(private val layoutResId: Int) :
         )
     }
 
-    private class DiffCallback(private val oldList: List<Any>, private val newList: List<Any>) :
+    private class DiffCallback<T>(private val oldList: List<T>, private val newList: List<T>) :
         DiffUtil.Callback() {
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             val oldItem = oldList[oldItemPosition]
@@ -413,38 +410,5 @@ class QuickAdapter(private val layoutResId: Int) :
                 }
             }
         }
-
-
-    }
-
-
-    // TODO
-    private class DawnLoadMoreView : BaseLoadMoreView() {
-        override fun getLoadComplete(holder: BaseViewHolder): View {
-            TODO("Not yet implemented")
-//        return holder.findView(R.id.load_more_load_complete_view);
-        }
-
-        override fun getLoadEndView(holder: BaseViewHolder): View {
-            TODO("Not yet implemented")
-//        return holder.findView(R.id.load_more_load_end_view);
-        }
-
-        override fun getLoadFailView(holder: BaseViewHolder): View {
-            TODO("Not yet implemented")
-//        return holder.findView(R.id.load_more_load_fail_view);
-        }
-
-        override fun getLoadingView(holder: BaseViewHolder): View {
-            TODO("Not yet implemented")
-//        return holder.findView(R.id.load_more_loading_view);
-        }
-
-        override fun getRootView(parent: ViewGroup): View {
-            TODO("Not yet implemented")
-            // 布局中 “加载失败”的View
-//        return LayoutInflater.from(parent.getContext()).inflate(R.layout.view_load_more, parent, false);
-        }
-
     }
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/adapters/QuickAdapter.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/adapters/QuickAdapter.kt
@@ -175,8 +175,8 @@ class QuickAdapter<T>(private val layoutResId: Int) :
         setText(R.id.timestamp, ContentTransformation.transformTime(now))
     }
 
-    private fun BaseViewHolder.convertForumAndReply(replyCount: String?, forumDisplayName: String) {
-        val suffix = if (replyCount != null) " • $replyCount" else ""
+    private fun BaseViewHolder.convertForumAndReply(replyCount: String, forumDisplayName: String) {
+        val suffix = if (replyCount.isNotBlank()) " • $replyCount" else ""
         val spannableString = SpannableString(forumDisplayName + suffix)
         spannableString.setSpan(
             RoundBackgroundColorSpan(
@@ -200,7 +200,7 @@ class QuickAdapter<T>(private val layoutResId: Int) :
                 title,
                 name
             )
-        if (titleAndName != "") {
+        if (titleAndName.isNotBlank()) {
             setText(R.id.titleAndName, titleAndName)
             setVisible(R.id.titleAndName, true)
         } else {
@@ -217,7 +217,7 @@ class QuickAdapter<T>(private val layoutResId: Int) :
     }
 
     private fun BaseViewHolder.convertImage(img: String, ext: String) {
-        if (img != "") {
+        if (img.isNotBlank()) {
             GlideApp.with(context)
                 .load(Constants.thumbCDN + img + ext)
 //                .override(400, 400)
@@ -355,14 +355,14 @@ class QuickAdapter<T>(private val layoutResId: Int) :
         class ThreadPayload(
             val now: String,
             val content: String,
-            val sage: String?,
-            val replyCount: String?
+            val sage: String,
+            val replyCount: String
         )
 
         class ReplyPayload(
             val now: String,
             val content: String,
-            val sage: String?
+            val sage: String
         )
     }
 

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/feeds/FeedsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/feeds/FeedsFragment.kt
@@ -95,15 +95,15 @@ class FeedsFragment : DaggerFragment() {
 
         val imageLoader = ImageLoader()
 
-        val mAdapter = QuickAdapter(R.layout.list_item_thread).apply {
+        val mAdapter = QuickAdapter<Thread>(R.layout.list_item_thread).apply {
 
             /*** connect SharedVm and adapter
              *  may have better way of getting runtime data
              */
             setSharedVM(sharedVM)
 
-            setOnItemClickListener { adapter, _, position ->
-                sharedVM.setThread(adapter.getItem(position) as Thread)
+            setOnItemClickListener { _, _, position ->
+                sharedVM.setThread(getItem(position))
                 val action =
                     PagerFragmentDirections.actionPagerFragmentToReplyFragment()
                 /**
@@ -113,8 +113,8 @@ class FeedsFragment : DaggerFragment() {
             }
 
             // long click to delete
-            setOnItemLongClickListener { adapter, _, position ->
-                val id = (adapter.getItem(position) as Thread).id
+            setOnItemLongClickListener { _, _, position ->
+                val id = getItem(position).id
                 MaterialDialog(requireContext()).show {
                     title(text = "删除订阅 $id?")
                     positiveButton(R.string.delete) {
@@ -127,11 +127,9 @@ class FeedsFragment : DaggerFragment() {
             }
 
             addChildClickViewIds(R.id.attachedImage)
-            setOnItemChildClickListener { adapter, view, position ->
+            setOnItemChildClickListener { _, view, position ->
                 if (view.id == R.id.attachedImage) {
-                    val url = (adapter.getItem(
-                        position
-                    ) as Thread).getImgUrl()
+                    val url = getItem(position).getImgUrl()
 
                     // TODO support multiple image
                     val viewerPopup =

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/feeds/FeedsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/feeds/FeedsFragment.kt
@@ -33,8 +33,6 @@ import com.lxj.xpopup.XPopup
 import dagger.android.support.DaggerFragment
 import me.dkzwm.widget.srl.RefreshingListenerAdapter
 import me.dkzwm.widget.srl.config.Constants
-import me.dkzwm.widget.srl.extra.header.ClassicHeader
-import me.dkzwm.widget.srl.indicator.IIndicator
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -170,7 +168,6 @@ class FeedsFragment : DaggerFragment() {
         }
 
         binding.refreshLayout.apply {
-            setHeaderView(ClassicHeader<IIndicator>(context))
             setOnRefreshListener(object : RefreshingListenerAdapter() {
                 override fun onRefreshing() {
                     mAdapter.setList(emptyList())

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/replys/JumpPopup.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/replys/JumpPopup.kt
@@ -54,7 +54,7 @@ class JumpPopup(context: Context) : CenterPopupView(context) {
         submitButton.setOnClickListener {
             submit = true
             targetPage = pageInput.text.toString().toInt()
-            if (applicationDataStore.cookies.isNullOrEmpty() && targetPage > 99) {
+            if (applicationDataStore.firstCookieHash == null && targetPage > 99) {
                 MaterialDialog(context).show {
                     message(R.string.need_cookie_to_read)
                 }

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/replys/QuotePopup.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/replys/QuotePopup.kt
@@ -96,7 +96,7 @@ class QuotePopup(private val caller: DaggerFragment, context: Context) : CenterP
         findViewById<TextView>(R.id.userId).text =
             transformCookie(
                 quote!!.userid,
-                quote!!.admin!!,
+                quote!!.admin,
                 mPo
             )
 

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysFragment.kt
@@ -37,8 +37,6 @@ import com.lxj.xpopup.interfaces.SimpleCallback
 import dagger.android.support.DaggerFragment
 import me.dkzwm.widget.srl.RefreshingListenerAdapter
 import me.dkzwm.widget.srl.config.Constants
-import me.dkzwm.widget.srl.extra.header.ClassicHeader
-import me.dkzwm.widget.srl.indicator.IIndicator
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -82,10 +80,10 @@ class ReplysFragment : DaggerFragment() {
             }
         }
 
-        // initial loading animation only, actual loading is triggered by sharedVM
-//        if (viewModel.replys.value.isNullOrEmpty()) {
-//            binding.refreshLayout.autoRefresh(Constants.ACTION_NOTHING, false)
-//        }
+//         initial loading animation only, actual loading is triggered by sharedVM
+        if (viewModel.replys.value.isNullOrEmpty()) {
+            binding.refreshLayout.autoRefresh(Constants.ACTION_NOTHING, false)
+        }
 
         val imageLoader = ImageLoader()
         val postPopup: PostPopup by lazyOnMainOnly { PostPopup(this, requireContext()) }
@@ -146,7 +144,6 @@ class ReplysFragment : DaggerFragment() {
         }
 
         binding.refreshLayout.apply {
-            setHeaderView(ClassicHeader<IIndicator>(context))
             setOnRefreshListener(object : RefreshingListenerAdapter() {
                 override fun onRefreshing() {
                     viewModel.getPreviousPage()

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysFragment.kt
@@ -78,11 +78,6 @@ class ReplysFragment : DaggerFragment() {
             }
         }
 
-//         initial loading animation only, actual loading is triggered by sharedVM
-        if (viewModel.replys.value.isNullOrEmpty()) {
-            binding.refreshLayout.autoRefresh(Constants.ACTION_NOTHING, false)
-        }
-
         val imageLoader = ImageLoader()
         val postPopup: PostPopup by lazyOnMainOnly { PostPopup(this, requireContext()) }
         val jumpPopup: JumpPopup by lazyOnMainOnly { JumpPopup(requireContext()) }
@@ -190,7 +185,7 @@ class ReplysFragment : DaggerFragment() {
         })
 
         sharedVM.selectedThreadId.observe(viewLifecycleOwner, Observer {
-            viewModel.setThread(it)
+            viewModel.setThreadId(it)
             updateTitle()
             updateSubtitle()
         })

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysFragment.kt
@@ -67,8 +67,6 @@ class ReplysFragment : DaggerFragment() {
 
         binding.toolbarLayout.toolbar.apply {
             immersiveToolbar()
-            title = "A岛 • ${sharedVM.getCurrentForumDisplayName()}"
-            setSubtitle(R.string.adnmb)
             val drawerLayout = requireActivity().findViewById<DrawerLayout>(R.id.drawerLayout)
             drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
             setNavigationIcon(R.drawable.ic_arrow_back_white_24px)
@@ -191,8 +189,9 @@ class ReplysFragment : DaggerFragment() {
             Timber.i("${this.javaClass.simpleName} Adapter will have ${it.size} threads")
         })
 
-        sharedVM.selectedThread.observe(viewLifecycleOwner, Observer {
+        sharedVM.selectedThreadId.observe(viewLifecycleOwner, Observer {
             viewModel.setThread(it)
+            updateTitle()
             updateSubtitle()
         })
 
@@ -319,6 +318,10 @@ class ReplysFragment : DaggerFragment() {
         } else {
             showMenu()
         }
+    }
+
+    private fun updateTitle() {
+        binding.toolbarLayout.toolbar.title = "A岛 • ${sharedVM.getSelectedThreadForumName()}"
     }
 
     private fun updateSubtitle() {

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysViewModel.kt
@@ -5,25 +5,11 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.laotoua.dawnislandk.data.local.Reply
-import com.laotoua.dawnislandk.data.local.Thread
 import com.laotoua.dawnislandk.data.repository.ReplyRepository
 import com.laotoua.dawnislandk.util.LoadingStatus
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.collections.List
-import kotlin.collections.MutableList
-import kotlin.collections.emptyList
-import kotlin.collections.first
-import kotlin.collections.firstOrNull
-import kotlin.collections.indexOfLast
-import kotlin.collections.indices
-import kotlin.collections.isNullOrEmpty
-import kotlin.collections.last
-import kotlin.collections.lastOrNull
-import kotlin.collections.map
-import kotlin.collections.mutableListOf
-import kotlin.collections.mutableMapOf
 import kotlin.collections.set
 
 class ReplysViewModel @Inject constructor(private val replyRepo: ReplyRepository) : ViewModel() {
@@ -59,9 +45,9 @@ class ReplysViewModel @Inject constructor(private val replyRepo: ReplyRepository
 
     var direction = DIRECTION.NEXT
 
-    fun setThread(f: Thread) {
-        if (f.id != currentThreadId) clearCache()
-        replyRepo.setThread(f)
+    fun setThread(id: String) {
+        if (id != currentThreadId) clearCache()
+        replyRepo.setThread(id)
         if (replyList.isEmpty()) getNextPage(false)
     }
 

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/replys/ReplysViewModel.kt
@@ -1,16 +1,9 @@
 package com.laotoua.dawnislandk.screens.replys
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.laotoua.dawnislandk.DawnApp.Companion.applicationDataStore
+import androidx.lifecycle.*
 import com.laotoua.dawnislandk.data.local.Reply
 import com.laotoua.dawnislandk.data.local.Thread
-import com.laotoua.dawnislandk.data.remote.APISuccessMessageResponse
-import com.laotoua.dawnislandk.data.remote.MessageType
-import com.laotoua.dawnislandk.data.remote.NMBServiceClient
-import com.laotoua.dawnislandk.data.repository.DataResource
+import com.laotoua.dawnislandk.data.repository.ReplyRepository
 import com.laotoua.dawnislandk.util.EventPayload
 import com.laotoua.dawnislandk.util.LoadingStatus
 import com.laotoua.dawnislandk.util.SingleLiveEvent
@@ -18,266 +11,139 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
-class ReplysViewModel @Inject constructor(private val webService: NMBServiceClient) : ViewModel() {
-    private var _currentThread: Thread? = null
-    val currentThread: Thread? get() = _currentThread
+class ReplysViewModel @Inject constructor(private val replyRepo: ReplyRepository) : ViewModel() {
+    val currentThreadId: String? get() = replyRepo.currentThreadId
+    val po get() = replyRepo.po
+
     private val replyList = mutableListOf<Reply>()
-    private val replyIds = mutableSetOf<String>()
-    private var _replys = MutableLiveData<List<Reply>>()
-    val replys: LiveData<List<Reply>> get() = _replys
-
-    private var fullPage = false
-
-    private var maxReply = 0
-
-    private var _po: String = ""
-    val po get() = _po
 
     // TODO: previous page & next page should be handled the same
-    var previousPage = mutableListOf<Reply>()
+    var previousPage: List<Reply> = emptyList()
+    val replys = MediatorLiveData<MutableList<Reply>>().apply {
+        addSource(replyRepo.emptyPage) {
+            if (it == true) {
+                val emptyPage = replyRepo.attachAdAndHead(emptyList(), 1)
+                handleNewPageData(emptyPage, DIRECTION.NEXT)
+                mLoadingStatus.value = SingleLiveEvent.create(LoadingStatus.NODATA)
+            }
+        }
+    }
 
-    val maxPage get() = 1.coerceAtLeast(kotlin.math.ceil(maxReply.toDouble() / 19).toInt())
+    private val listeningPages = mutableMapOf<Int, LiveData<List<Reply>>>()
+    val maxPage get() = replyRepo.maxPage
 
-    private var _loadingStatus = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
-    val loadingStatus: LiveData<SingleLiveEvent<EventPayload<Nothing>>>
-        get() = _loadingStatus
+    private val mLoadingStatus = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
+    val loadingStatus = MediatorLiveData<SingleLiveEvent<EventPayload<Nothing>>>().apply {
+        addSource(replyRepo.loadingStatus) { value = it }
+        addSource(mLoadingStatus) { value = it }
+    }
 
-    private val _addFeedResponse = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
-    val addFeedResponse: LiveData<SingleLiveEvent<EventPayload<Nothing>>> get() = _addFeedResponse
+    val addFeedResponse
+        get() = replyRepo.addFeedResponse
 
     enum class DIRECTION {
         NEXT,
         PREVIOUS
     }
 
-    var direction: DIRECTION =
-        DIRECTION.NEXT
+    var direction = DIRECTION.NEXT
 
     fun setThread(f: Thread) {
-        if (f.id == currentThread?.id ?: "") return
-        Timber.i("Thread has changed... Clearing old data")
-        replyList.clear()
-        replyIds.clear()
-        Timber.i("Setting new Thread: ${f.id}")
-        _currentThread = f
-        getNextPage()
+        if (f.id != currentThreadId) clearCache()
+        replyRepo.setThread(f)
+        if (replyList.isEmpty()) getNextPage(false)
     }
 
-    fun getNextPage() {
-        var page = 1
-        if (replyList.isNotEmpty()) page = replyList.last().page!!
-        if (fullPage) page += 1
-        direction =
-            DIRECTION.NEXT
-        getReplys(
-            page,
-            DIRECTION.NEXT
-        )
+    /** sometimes VM is KILLED but repo IS ALIVE, cache in Repo
+     *  may show current page is full so should get next page,
+     *  but VM still needs the cached current page to display
+     */
+    fun getNextPage(incrementPage: Boolean = true) {
+        direction = DIRECTION.NEXT
+        var nextPage = replyList.lastOrNull()?.page ?: 1
+        if (incrementPage && replyRepo.checkFullPage(nextPage)) nextPage += 1
+        listenToNewPage(nextPage, direction)
     }
 
     fun getPreviousPage() {
-
+        direction = DIRECTION.PREVIOUS
         // Refresh when no data, usually error occurs
-        if (replyList.isEmpty()) {
-            _loadingStatus.postValue(
-                SingleLiveEvent.create(
-                    LoadingStatus.LOADING
-                )
-            )
+        if (replyList.isNullOrEmpty()) {
             getNextPage()
             return
         }
-        val page = replyList.first().page!!.toInt()
-        if (page == 1) {
-            _loadingStatus.postValue(
-                SingleLiveEvent.create(
-                    LoadingStatus.NODATA,
-                    "没有上一页了..."
-
-                )
-            )
+        val lastPage = (replyList.firstOrNull()?.page ?: 1) - 1
+        if (lastPage < 1) {
+            replyRepo.loadingStatus.value =
+                SingleLiveEvent.create(LoadingStatus.NODATA, "没有上一页了...")
             return
         }
+        listenToNewPage(lastPage, direction)
+    }
 
-        previousPage.clear()
-        direction =
-            DIRECTION.PREVIOUS
-        getReplys(
-            page - 1,
-            DIRECTION.PREVIOUS
-        )
+
+    private fun listenToNewPage(page: Int, direction: DIRECTION) {
+        val newPage = replyRepo.getLiveDataOnPage(page)
+        if (listeningPages[page] != newPage) {
+            listeningPages[page] = newPage
+            replys.addSource(newPage) {
+                val pageWithAdAndHead = replyRepo.attachAdAndHead(it, page)
+                if (!pageWithAdAndHead.isNullOrEmpty()) {
+                    handleNewPageData(pageWithAdAndHead, direction)
+                }
+            }
+        } else {
+            viewModelScope.launch {
+                replyRepo.getServerData(page)
+            }
+        }
+    }
+
+    private fun mergeNewPage(list: MutableList<Reply>, direction: DIRECTION) {
+        if (list.isNullOrEmpty()) return
+        val targetPage = list.first().page
+        if (direction == DIRECTION.PREVIOUS) {
+            replyList.addAll(0, list)
+            previousPage = list
+        } else if (replyList.isEmpty() || targetPage > replyList.last().page) {
+            replyList.addAll(list)
+        } else {
+            val ind = replyList.indexOfLast { it.page < targetPage } + 1
+            for (i in list.indices) {
+                when {
+                    (ind + i >= replyList.size || replyList[ind + i].page > list[i].page) -> {
+                        replyList.add(ind + i, list[i])
+                    }
+                    replyList[ind + i].page == list[i].page -> replyList[ind + i] = list[i]
+                    else -> throw Exception("replyList insertion error")
+                }
+            }
+        }
+    }
+
+    private fun handleNewPageData(list: MutableList<Reply>, direction: DIRECTION) {
+        mergeNewPage(list, direction)
+        replys.postValue(replyList)
+        mLoadingStatus.value = SingleLiveEvent.create(LoadingStatus.SUCCESS)
+    }
+
+    private fun clearCache() {
+        listeningPages.values.map { replys.removeSource(it) }
+        listeningPages.clear()
+        replyList.clear()
     }
 
     fun jumpTo(page: Int) {
         Timber.i("Jumping to page $page... Clearing old data")
-        replyList.clear()
-        replyIds.clear()
-        direction =
-            DIRECTION.NEXT
-        getReplys(
-            page,
-            DIRECTION.NEXT
-        )
-    }
-
-    private fun getReplys(page: Int, direction: DIRECTION) {
-        if (_currentThread == null) {
-            Timber.e("Trying to read replys without selected forum")
-            return
-        }
-
-        viewModelScope.launch {
-            _loadingStatus.postValue(
-                SingleLiveEvent.create(
-                    LoadingStatus.LOADING
-                )
-            )
-            DataResource.create(
-                webService.getReplys(
-                    applicationDataStore.cookies.firstOrNull()?.cookieHash,
-                    _currentThread!!.id,
-                    page
-                )
-            ).run {
-                when (this) {
-                    is DataResource.Success -> {
-                        convertServerData(data!!, page, direction)
-                    }
-                    is DataResource.Error -> {
-                        Timber.e(message)
-                        _loadingStatus.postValue(
-                            SingleLiveEvent.create(
-                                LoadingStatus.FAILED,
-                                "无法读取串回复...\n$message"
-                            )
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private fun convertServerData(data: Thread, page: Int, direction: DIRECTION) {
-        // update current thread with latest info
-        _currentThread = data
-        _po = data.userid
-
-        val list = mutableListOf<Reply>()
-        maxReply = data.replyCount?.toInt() ?: 0
-        list.addAll(data.replys!!)
-        /**
-         *  w. cookie, responses have 20 reply w. ad, or 19 reply w/o ad
-         *  w/o cookie, always have 20 reply w. ad
-         *  MARK full page for next page load
-         */
-        fullPage =
-            (list.size == 20 || (list.size == 19 && list.first().id != "9999999"))
-
-        // add thread to as first reply for page 1
-        if (page == 1 && !replyIds.contains(data.id)) {
-            replyList.add(0, data.toReply())
-            replyIds.add(data.id)
-
-            _replys.postValue(replyList)
-            // TODO: previous page & next page should be handled the same
-            if (direction == DIRECTION.PREVIOUS) previousPage.add(data.toReply())
-        }
-
-        val noDuplicates =
-            list.filterNot { replyIds.contains(it.id) && it.id != "9999999" }
-
-        if ((noDuplicates.isNotEmpty() &&
-                    (noDuplicates.size > 1 || noDuplicates.first().id != "9999999"))
-        ) {
-            replyIds.addAll(noDuplicates.map { it.id })
-            Timber.i(
-                "No duplicate reply size ${noDuplicates.size}, replyIds size ${replyIds.size}"
-            )
-
-            // add page to Reply
-            noDuplicates.apply { map { it.page = page } }
-                .let {
-                    if (direction == DIRECTION.NEXT) {
-                        replyList.addAll(it)
-                    } else {
-                        val insertInd = if (page == 1) 1 else 0
-                        replyList.addAll(insertInd, it)
-                        // TODO: previous page & next page should be handled the same
-                        previousPage.addAll(it)
-                    }
-                }
-
-            _replys.postValue(replyList)
-            _loadingStatus.postValue(
-                SingleLiveEvent.create(
-                    LoadingStatus.SUCCESS
-                )
-            )
-
-            Timber.i("CurrentPage: $page ReplyIds(w. ad, head): ${replyIds.size} replyList: ${replyList.size} replyCount: $maxReply")
-        } else {
-            Timber.i("Thread ${data.id} has no new replys.")
-            _loadingStatus.postValue(
-                SingleLiveEvent.create(
-                    LoadingStatus.NODATA
-                )
-            )
-
-        }
+        direction = DIRECTION.NEXT
+        clearCache()
+        listenToNewPage(page, direction)
     }
 
     // TODO: do not send request if subscribe already
     fun addFeed(uuid: String, id: String) {
-        Timber.i("Adding Feed $id")
         viewModelScope.launch {
-            webService.addFeed(uuid, id).run {
-                when (this) {
-                    is APISuccessMessageResponse -> {
-                        if (messageType == MessageType.String) {
-                            _addFeedResponse.postValue(
-                                SingleLiveEvent.create(
-                                    LoadingStatus.SUCCESS,
-                                    message
-                                )
-                            )
-                        } else {
-                            Timber.e(message)
-                        }
-                    }
-                    else -> {
-                        Timber.e("Response type: ${this.javaClass.simpleName}\n $message")
-                        _addFeedResponse.postValue(
-                            SingleLiveEvent.create(
-                                LoadingStatus.FAILED,
-                                "订阅失败...是不是已经订阅了呢?"
-                            )
-                        )
-                    }
-                }
-            }
+            replyRepo.addFeed(uuid, id)
         }
     }
-    // TODO
-//    fun loadFromDB() {
-//        viewModelScope.launch {
-//            withContext(Dispatchers.IO) {
-//                dao?.getAll().let {
-//                    if (it?.size ?: 0 > 0) {
-//                        Timber.i("Loaded ${it?.size} replys from db")
-//                        _replyList.postValue(it)
-//                    } else {
-//                        Timber.i("Db has no data about replys")
-//                    }
-//                }
-//            }
-//        }
-//    }
-
-    // TODO
-//    fun setDb(dao: ForumDao) {
-//        this.dao = dao
-//        Timber.i("Forum DAO set!!!")
-//    }
-
-
 }

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/settings/SettingsFragment.kt
@@ -46,7 +46,7 @@ class SettingsFragment : Fragment() {
             positiveButton(R.string.submit) {
                 val cookieName = findViewById<EditText>(R.id.cookieNameText).text
                 val cookieHash = findViewById<EditText>(R.id.cookieHashText).text
-                if (cookieHash.toString() != "") {
+                if (cookieHash.toString().isNotBlank()) {
                     addCookie(
                         Cookie(
                             cookieHash.toString(),

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsFragment.kt
@@ -60,7 +60,6 @@ class ThreadsFragment : DaggerFragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.toolbarLayout.toolbar.apply {
             immersiveToolbar()
-            updateTitle()
             setSubtitle(R.string.adnmb)
             val drawerLayout = requireActivity().findViewById<DrawerLayout>(R.id.drawerLayout)
             drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
@@ -172,17 +171,14 @@ class ThreadsFragment : DaggerFragment() {
             Timber.i("${this.javaClass.simpleName} Adapter will have ${it.size} threads")
         })
 
-        sharedVM.selectedForum.observe(viewLifecycleOwner, Observer {
-            if (viewModel.currentForum == null) {
-                viewModel.setForum(it)
-            } else if (viewModel.currentForum != null && viewModel.currentForum!!.id != it.id) {
-                Timber.i("Forum has changed to ${it.name}. Cleaning old adapter data...")
+        sharedVM.selectedForumId.observe(viewLifecycleOwner, Observer {
+            if (viewModel.currentFid != null && viewModel.currentFid != it) {
+                Timber.d("Forum has changed to $it. Cleaning old adapter data...")
                 mAdapter.setList(emptyList())
-                viewModel.setForum(it)
-                hideMenu()
-
-                updateTitle()
             }
+            viewModel.setForum(it)
+            updateTitle(it)
+            hideMenu()
         })
 
         binding.fabMenu.setOnClickListener {
@@ -203,7 +199,7 @@ class ThreadsFragment : DaggerFragment() {
         binding.post.setOnClickListener {
             hideMenu()
             postPopup.setupAndShow(
-                sharedVM.selectedForum.value?.id,
+                sharedVM.selectedForumId.value,
                 true,
                 sharedVM.getForumNameMapping()
             )
@@ -258,8 +254,8 @@ class ThreadsFragment : DaggerFragment() {
         }
     }
 
-    private fun updateTitle() {
-        binding.toolbarLayout.toolbar.title = "A岛 • ${viewModel.currentForum?.name ?: "时间线"}"
+    private fun updateTitle(fid: String) {
+        binding.toolbarLayout.toolbar.title = "A岛 • ${sharedVM.getForumDisplayName(fid)}"
     }
 }
 

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsFragment.kt
@@ -32,8 +32,6 @@ import com.lxj.xpopup.XPopup
 import dagger.android.support.DaggerFragment
 import me.dkzwm.widget.srl.RefreshingListenerAdapter
 import me.dkzwm.widget.srl.config.Constants
-import me.dkzwm.widget.srl.extra.header.ClassicHeader
-import me.dkzwm.widget.srl.indicator.IIndicator
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -134,7 +132,6 @@ class ThreadsFragment : DaggerFragment() {
         }
 
         binding.refreshLayout.apply {
-            setHeaderView(ClassicHeader<IIndicator>(context))
             setOnRefreshListener(object : RefreshingListenerAdapter() {
                 override fun onRefreshing() {
                     mAdapter.setList(emptyList())

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsFragment.kt
@@ -87,15 +87,15 @@ class ThreadsFragment : DaggerFragment() {
         val imageLoader = ImageLoader()
         val postPopup: PostPopup by lazyOnMainOnly { PostPopup(this, requireContext()) }
 
-        val mAdapter = QuickAdapter(R.layout.list_item_thread).apply {
+        val mAdapter = QuickAdapter<Thread>(R.layout.list_item_thread).apply {
             /*** connect SharedVm and adapter
              *  may have better way of getting runtime data
              */
             setSharedVM(sharedVM)
 
-            setOnItemClickListener { adapter, _, position ->
+            setOnItemClickListener { _, _, position ->
                 hideMenu()
-                sharedVM.setThread(adapter.getItem(position) as Thread)
+                sharedVM.setThread(getItem(position))
                 val action =
                     PagerFragmentDirections.actionPagerFragmentToReplyFragment()
                 /**
@@ -105,12 +105,10 @@ class ThreadsFragment : DaggerFragment() {
             }
 
             addChildClickViewIds(R.id.attachedImage)
-            setOnItemChildClickListener { adapter, view, position ->
+            setOnItemChildClickListener { _, view, position ->
                 if (view.id == R.id.attachedImage) {
                     hideMenu()
-                    val url = (adapter.getItem(
-                        position
-                    ) as Thread).getImgUrl()
+                    val url = getItem(position).getImgUrl()
 
                     // TODO support multiple image
                     val viewerPopup =

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsViewModel.kt
@@ -18,8 +18,8 @@ import javax.inject.Inject
 class ThreadsViewModel @Inject constructor(private val webService: NMBServiceClient) : ViewModel() {
     private val threadList = mutableListOf<Thread>()
     private val threadIds = mutableSetOf<String>()
-    private var _threads = MutableLiveData<List<Thread>>()
-    val threads: LiveData<List<Thread>> get() = _threads
+    private var _threads = MutableLiveData<MutableList<Thread>>()
+    val threads: LiveData<MutableList<Thread>> get() = _threads
     private var _currentForum: Forum? = null
     val currentForum: Forum? get() = _currentForum
     private var pageCount = 1

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/threads/ThreadsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.laotoua.dawnislandk.data.local.Forum
 import com.laotoua.dawnislandk.data.local.Thread
 import com.laotoua.dawnislandk.data.remote.NMBServiceClient
 import com.laotoua.dawnislandk.data.repository.DataResource
@@ -20,8 +19,8 @@ class ThreadsViewModel @Inject constructor(private val webService: NMBServiceCli
     private val threadIds = mutableSetOf<String>()
     private var _threads = MutableLiveData<MutableList<Thread>>()
     val threads: LiveData<MutableList<Thread>> get() = _threads
-    private var _currentForum: Forum? = null
-    val currentForum: Forum? get() = _currentForum
+    private var _currentFid: String? = null
+    val currentFid: String? get() = _currentFid
     private var pageCount = 1
 
     private var _loadingStatus = MutableLiveData<SingleLiveEvent<EventPayload<Nothing>>>()
@@ -35,8 +34,8 @@ class ThreadsViewModel @Inject constructor(private val webService: NMBServiceCli
                     LoadingStatus.LOADING
                 )
             )
-            val fid = _currentForum?.id ?: "-1"
-            Timber.i("Getting threads from $fid ${_currentForum?.name} on page $pageCount")
+            val fid = _currentFid ?: "-1"
+            Timber.d("Getting threads from $fid on page $pageCount")
             DataResource.create(webService.getThreads(fid, pageCount)).run {
                 when (this) {
                     is DataResource.Error -> {
@@ -63,8 +62,8 @@ class ThreadsViewModel @Inject constructor(private val webService: NMBServiceCli
         if (noDuplicates.isNotEmpty()) {
             threadIds.addAll(noDuplicates.map { it.id })
             threadList.addAll(noDuplicates)
-            Timber.i(
-                "New thread + ads has size of ${noDuplicates.size}, threadIds size ${threadIds.size}, Forum ${currentForum?.name} now have ${threadList.size} threads"
+            Timber.d(
+                "New thread + ads has size of ${noDuplicates.size}, threadIds size ${threadIds.size}, Forum $currentFid now have ${threadList.size} threads"
             )
             _threads.postValue(threadList)
             _loadingStatus.postValue(
@@ -74,8 +73,8 @@ class ThreadsViewModel @Inject constructor(private val webService: NMBServiceCli
             )
             pageCount += 1
         } else {
-            val message = "Forum ${currentForum?.getDisplayName()} has no new threads."
-            Timber.i(message)
+            val message = "Forum $currentFid has no new threads."
+            Timber.d(message)
             _loadingStatus.postValue(
                 SingleLiveEvent.create(
                     LoadingStatus.FAILED,
@@ -85,19 +84,19 @@ class ThreadsViewModel @Inject constructor(private val webService: NMBServiceCli
         }
     }
 
-    fun setForum(f: Forum) {
-        if (f == currentForum) return
+    fun setForum(fid: String) {
+        if (fid == currentFid) return
         Timber.i("Forum has changed. Cleaning old threads...")
         threadList.clear()
         threadIds.clear()
-        Timber.i("Setting new forum: ${f.id}")
-        _currentForum = f
+        Timber.d("Setting new forum: $fid")
+        _currentFid = fid
         pageCount = 1
         getThreads()
     }
 
     fun refresh() {
-        Timber.i("Refreshing forum ${currentForum!!.name}...")
+        Timber.d("Refreshing forum $currentFid...")
         threadList.clear()
         threadIds.clear()
         pageCount = 1

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsFragment.kt
@@ -26,8 +26,6 @@ import com.laotoua.dawnislandk.screens.util.ToolBar.immersiveToolbar
 import dagger.android.support.DaggerFragment
 import me.dkzwm.widget.srl.RefreshingListenerAdapter
 import me.dkzwm.widget.srl.config.Constants
-import me.dkzwm.widget.srl.extra.header.ClassicHeader
-import me.dkzwm.widget.srl.indicator.IIndicator
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -98,7 +96,6 @@ class TrendsFragment : DaggerFragment() {
         }
 
         binding.refreshLayout.apply {
-            setHeaderView(ClassicHeader<IIndicator>(context))
             setOnRefreshListener(object : RefreshingListenerAdapter() {
                 override fun onRefreshing() {
                     viewModel.refresh()

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsFragment.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsFragment.kt
@@ -68,10 +68,10 @@ class TrendsFragment : DaggerFragment() {
             mHandler = mHandler ?: Handler()
             delayedLoading = mHandler!!.postDelayed(mDelayedLoad, 500)
         }
-        val mAdapter = QuickAdapter(R.layout.list_item_trend).apply {
+        val mAdapter = QuickAdapter<Trend>(R.layout.list_item_trend).apply {
             loadMoreModule.isEnableLoadMore = false
-            setOnItemClickListener { adapter, _, position ->
-                val target = adapter.getItem(position) as Trend
+            setOnItemClickListener { _, _, position ->
+                val target = getItem(position)
                 sharedVM.setThread(target.toThread(sharedVM.getForumIdByName(target.forum)))
                 val action =
                     PagerFragmentDirections.actionPagerFragmentToReplyFragment()

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsViewModel.kt
@@ -21,8 +21,8 @@ class TrendsViewModel @Inject constructor(private val webService: NMBServiceClie
     private val po = "m9R9kaD"
     private val trendDelimiter = "\n\u2014\u2014\u2014\u2014\u2014<br />\n<br />\n"
 
-    private var _trendList = MutableLiveData<List<Trend>>()
-    val trends: LiveData<List<Trend>> get() = _trendList
+    private var _trendList = MutableLiveData<MutableList<Trend>>()
+    val trends: LiveData<MutableList<Trend>> get() = _trendList
 
     private val trendLength = 32
     private var page = 1
@@ -93,7 +93,7 @@ class TrendsViewModel @Inject constructor(private val webService: NMBServiceClie
 
 
     private fun convertTrendData(trends: List<String>) {
-        _trendList.postValue(trends.map { convertStringToTrend(it) })
+        _trendList.postValue(trends.map { convertStringToTrend(it) }.toMutableList())
         _loadingStatus.postValue(
             SingleLiveEvent.create(
                 LoadingStatus.SUCCESS

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsViewModel.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/trend/TrendsViewModel.kt
@@ -45,14 +45,14 @@ class TrendsViewModel @Inject constructor(private val webService: NMBServiceClie
     private suspend fun getLatestTrendPage() {
         DataResource.create(
             webService.getReplys(
-                applicationDataStore.cookies.firstOrNull()?.cookieHash,
+                applicationDataStore.firstCookieHash,
                 trendId,
                 page
             )
         ).run {
             when (this) {
                 is DataResource.Success -> {
-                    val count = data!!.replyCount?.toInt() ?: 0
+                    val count = data!!.replyCount.toInt()
                     if (page == 1) {
                         page = kotlin.math.ceil(count.toDouble() / 19).toInt()
                         getLatestTrendPage()
@@ -80,7 +80,7 @@ class TrendsViewModel @Inject constructor(private val webService: NMBServiceClie
     }
 
     private fun extractLatestTrend(data: Thread): List<String> {
-        for (reply in data.replys!!.reversed()) {
+        for (reply in data.replys.reversed()) {
             if (reply.userid == po) {
                 val list = reply.content.split(trendDelimiter, ignoreCase = true)
                 if (list.size == 32) {

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
@@ -34,9 +34,11 @@ object Layout {
         mAdapter: QuickAdapter<AdapterType>,
         event: EventPayload<PayloadType>
     ) {
+        val headerDismissalDelayDuration = 200L
         when (event.loadingStatus) {
+            // TODO: stick failure message on header or footer instead of toast
             LoadingStatus.FAILED -> {
-                refreshLayout.refreshComplete(false, 5L)
+                refreshLayout.refreshComplete(false, headerDismissalDelayDuration)
                 mAdapter.loadMoreModule.loadMoreFail()
                 Toast.makeText(
                     context,
@@ -45,7 +47,7 @@ object Layout {
                 ).show()
             }
             LoadingStatus.NODATA -> {
-                refreshLayout.refreshComplete(true, 100L)
+                refreshLayout.refreshComplete(true, headerDismissalDelayDuration)
                 mAdapter.loadMoreModule.loadMoreEnd()
                 if (event.message != null) {
                     Toast.makeText(
@@ -56,7 +58,7 @@ object Layout {
                 }
             }
             LoadingStatus.SUCCESS -> {
-                refreshLayout.refreshComplete(true, 100L)
+                refreshLayout.refreshComplete(true, headerDismissalDelayDuration)
                 mAdapter.loadMoreModule.loadMoreComplete()
             }
             LoadingStatus.LOADING -> {

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
@@ -29,10 +29,10 @@ object Layout {
         return pix / context.resources.displayMetrics.density
     }
 
-    fun <T> Fragment.updateHeaderAndFooter(
+    fun <AdapterType, PayloadType> Fragment.updateHeaderAndFooter(
         refreshLayout: SmoothRefreshLayout,
-        mAdapter: QuickAdapter,
-        event: EventPayload<T>
+        mAdapter: QuickAdapter<AdapterType>,
+        event: EventPayload<PayloadType>
     ) {
         when (event.loadingStatus) {
             LoadingStatus.FAILED -> {

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
@@ -36,7 +36,7 @@ object Layout {
     ) {
         when (event.loadingStatus) {
             LoadingStatus.FAILED -> {
-                refreshLayout.refreshComplete(false)
+                refreshLayout.refreshComplete(false, 5L)
                 mAdapter.loadMoreModule.loadMoreFail()
                 Toast.makeText(
                     context,
@@ -45,7 +45,7 @@ object Layout {
                 ).show()
             }
             LoadingStatus.NODATA -> {
-                refreshLayout.refreshComplete()
+                refreshLayout.refreshComplete(true, 5L)
                 mAdapter.loadMoreModule.loadMoreEnd()
                 if (event.message != null) {
                     Toast.makeText(
@@ -56,7 +56,7 @@ object Layout {
                 }
             }
             LoadingStatus.SUCCESS -> {
-                refreshLayout.refreshComplete()
+                refreshLayout.refreshComplete(true, 5L)
                 mAdapter.loadMoreModule.loadMoreComplete()
             }
             LoadingStatus.LOADING -> {

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/util/Layout.kt
@@ -45,7 +45,7 @@ object Layout {
                 ).show()
             }
             LoadingStatus.NODATA -> {
-                refreshLayout.refreshComplete(true, 5L)
+                refreshLayout.refreshComplete(true, 100L)
                 mAdapter.loadMoreModule.loadMoreEnd()
                 if (event.message != null) {
                     Toast.makeText(
@@ -56,7 +56,7 @@ object Layout {
                 }
             }
             LoadingStatus.SUCCESS -> {
-                refreshLayout.refreshComplete(true, 5L)
+                refreshLayout.refreshComplete(true, 100L)
                 mAdapter.loadMoreModule.loadMoreComplete()
             }
             LoadingStatus.LOADING -> {

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/widget/popup/PostPopup.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/widget/popup/PostPopup.kt
@@ -503,7 +503,7 @@ class PostPopup(private val caller: DaggerFragment, context: Context) :
         email = findViewById<TextView>(R.id.formEmail).text.toString()
         title = findViewById<TextView>(R.id.formTitle).text.toString()
         content = postContent!!.text.toString()
-        if (content == "" && imageFile == null) {
+        if (content.isBlank() && imageFile == null) {
             Toast.makeText(caller.context, R.string.need_content_to_post, Toast.LENGTH_SHORT).show()
             return
         }

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/widget/popup/PostPopup.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/widget/popup/PostPopup.kt
@@ -75,9 +75,9 @@ class PostPopup(private val caller: DaggerFragment, context: Context) :
     private var expansionContainer: LinearLayout? = null
     private var attachmentContainer: ConstraintLayout? = null
     private var emojiContainer: RecyclerView? = null
-    private val emojiAdapter: QuickAdapter by lazyOnMainOnly { QuickAdapter(R.layout.grid_item_emoji) }
+    private val emojiAdapter by lazyOnMainOnly { QuickAdapter<String>(R.layout.grid_item_emoji) }
     private var luweiStickerContainer: RecyclerView? = null
-    private val luweiStickerAdapter: QuickAdapter by lazyOnMainOnly { QuickAdapter(R.layout.grid_item_luwei_sticker) }
+    private val luweiStickerAdapter by lazyOnMainOnly { QuickAdapter<String>(R.layout.grid_item_luwei_sticker) }
     private var postContent: EditText? = null
     private var postImagePreview: ImageView? = null
 
@@ -272,7 +272,7 @@ class PostPopup(private val caller: DaggerFragment, context: Context) :
             luweiStickerContainer!!.layoutManager = GridLayoutManager(context, 3)
             luweiStickerContainer!!.adapter = luweiStickerAdapter.also { adapter ->
                 adapter.setOnItemClickListener { _, _, pos ->
-                    val emojiId = adapter.getItem(pos) as String
+                    val emojiId = adapter.getItem(pos)
                     val resourceId: Int = context.resources.getIdentifier(
                         "le$emojiId", "drawable",
                         context.packageName

--- a/app/src/main/java/com/laotoua/dawnislandk/util/GlobalExtensions.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/util/GlobalExtensions.kt
@@ -1,3 +1,11 @@
 package com.laotoua.dawnislandk.util
 
 fun <T> lazyOnMainOnly(initializer: () -> T): Lazy<T> = lazy(LazyThreadSafetyMode.NONE, initializer)
+
+/**
+ * returns true if list has been modified
+ */
+fun <E> MutableList<E>.addOrSet(ind: Int, element: E): Boolean {
+    return if (ind >= size) add(element)
+    else set(ind, element) == element
+}

--- a/app/src/main/res/layout/fragment_feed.xml
+++ b/app/src/main/res/layout/fragment_feed.xml
@@ -13,7 +13,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.dkzwm.widget.srl.SmoothRefreshLayout
+    <me.dkzwm.widget.srl.MaterialSmoothRefreshLayout
         android:id="@+id/refreshLayout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -27,6 +27,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical" />
-    </me.dkzwm.widget.srl.SmoothRefreshLayout>
+    </me.dkzwm.widget.srl.MaterialSmoothRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_reply.xml
+++ b/app/src/main/res/layout/fragment_reply.xml
@@ -13,7 +13,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.dkzwm.widget.srl.SmoothRefreshLayout
+    <me.dkzwm.widget.srl.MaterialSmoothRefreshLayout
         android:id="@+id/refreshLayout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -29,7 +29,7 @@
             android:scrollbars="vertical">
 
         </androidx.recyclerview.widget.RecyclerView>
-    </me.dkzwm.widget.srl.SmoothRefreshLayout>
+    </me.dkzwm.widget.srl.MaterialSmoothRefreshLayout>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/addFeed"

--- a/app/src/main/res/layout/fragment_thread.xml
+++ b/app/src/main/res/layout/fragment_thread.xml
@@ -13,7 +13,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.dkzwm.widget.srl.SmoothRefreshLayout
+    <me.dkzwm.widget.srl.MaterialSmoothRefreshLayout
         android:id="@+id/refreshLayout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -27,7 +27,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical" />
-    </me.dkzwm.widget.srl.SmoothRefreshLayout>
+    </me.dkzwm.widget.srl.MaterialSmoothRefreshLayout>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/setting"

--- a/app/src/main/res/layout/fragment_trend.xml
+++ b/app/src/main/res/layout/fragment_trend.xml
@@ -13,7 +13,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <me.dkzwm.widget.srl.SmoothRefreshLayout
+    <me.dkzwm.widget.srl.MaterialSmoothRefreshLayout
         android:id="@+id/refreshLayout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -29,6 +29,6 @@
             android:scrollbars="vertical">
 
         </androidx.recyclerview.widget.RecyclerView>
-    </me.dkzwm.widget.srl.SmoothRefreshLayout>
+    </me.dkzwm.widget.srl.MaterialSmoothRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.71'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         def nav_version = "2.3.0-alpha04"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"


### PR DESCRIPTION
**回复默认保存在数据库**
每一个api请求都会将数据保存在数据库，利用livedata，如果数据库更新了，新的值会传到repository，vm会监听对应的值然后传递给fragment
- changed Gson to Moshi for kotlin data class constructor support
- changed Community from sync data to async Livedata
- renamed table names to match class
- added ReplyDao and ThreadDao(currently unused)
- added retrofit network request 30s timeout
- added replyRepository
- moved logic from VM to Repo
- added type in QuickAdapter(no longer uses *Any*)
-  added thread table
- now uses threadId instead of thread for navigation(trend does not have valid thread)
- combined threadHead and first replys with new mediator live data(first replys wait until head finish loading to emit)
- added catch for empty pages display
- added job cancellation for thread changes in singleton repo
- fixed po
- extend headerDismissalDelayDuration to 200ms





