### PR TITLE
Default server feed category

### DIFF
--- a/app/src/main/java/com/laotoua/dawnislandk/data/local/entity/Feed.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/data/local/entity/Feed.kt
@@ -50,7 +50,7 @@ data class Feed(
     data class ServerFeed(
         @PrimaryKey val id: String,
         val fid: String = "",
-        val category: String,
+        val category: String = "",
         val img: String,
         val ext: String,
         val now: String,


### PR DESCRIPTION
对 #278 的修复
现在X岛API返回的内容中不再含有`category`, 给他一个默认值
```json
[
    {
        "id": "65690379",
        "fid": "4",
        "img": "",
        "ext": "",
        "now": "2025-03-30(日)15:53:36",
        "user_hash": "azPCIWL",
        "name": "",
        "email": "",
        "title": "",
        "content": "练气流控制，指挥说男低发出了直升飞机的声音，但我在旁边不敢笑，因为我唱得像蜜蜂",
        "admin": "0"
    },
]
```