### PR TITLE
Honor pinned CDN on cold start (fixes #277)

### DIFF
--- a/app/src/main/java/com/laotoua/dawnislandk/DawnApp.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/DawnApp.kt
@@ -99,6 +99,17 @@ class DawnApp : DaggerApplication() {
         // MMKV
         MMKV.initialize(this)
         MMKV.registerHandler(handler)
+
+        // Apply persisted CDN overrides before the first requests fire, so a
+        // user-pinned CDN is honored on cold start instead of falling through
+        // to NMBXDHost (which fails when nmbxd.com is DNS-poisoned).
+        applicationDataStore.getBaseCDN().let {
+            if (it != "auto") RetrofitUrlManager.getInstance().putDomain("nmb", it)
+        }
+        applicationDataStore.getRefCDN().let {
+            if (it != "auto") RetrofitUrlManager.getInstance().putDomain("nmb-ref", it)
+        }
+
         setDefaultDayNightMode()
         // Time
         ReadableTime.initialize(this)

--- a/app/src/main/java/com/laotoua/dawnislandk/screens/MainActivity.kt
+++ b/app/src/main/java/com/laotoua/dawnislandk/screens/MainActivity.kt
@@ -647,8 +647,10 @@ class MainActivity : DaggerAppCompatActivity() {
         RetrofitUrlManager.getInstance().putDomain("nmb-ref", DawnConstants.NMBXDHost)
 
         sharedVM.onNMBXD()
-        refreshApplicationCache()
+        // Re-point nmb/nmb-ref to the pinned CDN before refreshing, otherwise
+        // the refresh requests race to NMBXDHost first (issue #277).
         autoSelectCDNs()
+        refreshApplicationCache()
 
         sharedVM.setForumId(applicationDataStore.getDefaultForumId(), true)
 


### PR DESCRIPTION
When a user pins a default/reference CDN, the app still hit the hardcoded NMBXDHost (nmbxd.com) on cold start, because the saved CDN was only applied to RetrofitUrlManager when the setting was changed or ~3s after a network callback. On networks where nmbxd.com is DNS-poisoned, the early startup requests failed, which also surfaced as vanishing subscriptions and lost read/scroll history.

- DawnApp.onCreate: seed the nmb/nmb-ref domain mappings from the saved CDN right after MMKV init, so the first requests honor the pinned CDN.
- MainActivity.goToNMBXD: run autoSelectCDNs() before refreshApplicationCache() so a manual island switch doesn't race the refresh to NMBXDHost.