### PR TITLE
Ignore signing keystore and secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,10 @@ captures/
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
+*.pepk
+Pass.txt
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild


### PR DESCRIPTION
Enable the commented-out keystore ignore lines and add the Play upload-key export and password file, so the recovered signing material in the repo working dir can't be committed by an accidental 'git add .'.